### PR TITLE
Allowing to use HEAD^1 syntax for the referenceBranch option

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.vackosar.gitflowincrementalbuilder</groupId>
     <artifactId>gitflow-incremental-builder</artifactId>
-    <version>3.1</version>
+    <version>3.2-SNAPSHOT</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>A maven extension for incremental building of multi-module projects when using Git Flow.</description>
     <url>https://github.com/vackosar/gitflow-incremental-builder</url>

--- a/src/test/java/com/vackosar/gitflowincrementalbuild/BaseRepoTest.java
+++ b/src/test/java/com/vackosar/gitflowincrementalbuild/BaseRepoTest.java
@@ -1,39 +1,44 @@
-package com.vackosar.gitflowincrementalbuild.mocks;
+package com.vackosar.gitflowincrementalbuild;
 
 import com.vackosar.gitflowincrementalbuild.control.Property;
+import com.vackosar.gitflowincrementalbuild.mocks.LocalRepoMock;
+import com.vackosar.gitflowincrementalbuild.mocks.MavenSessionMock;
+
+import org.apache.maven.execution.MavenSession;
 import org.codehaus.plexus.logging.console.ConsoleLoggerManager;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
 import org.slf4j.impl.StaticLoggerBinder;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 
-public abstract class RepoTest {
+public abstract class BaseRepoTest {
 
     protected LocalRepoMock localRepoMock;
     private StaticLoggerBinder staticLoggerBinder;
     protected ByteArrayOutputStream consoleOut;
     private final PrintStream normalOut;
 
-    public RepoTest() {
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    public BaseRepoTest() {
         this.normalOut = System.out;
     }
 
     @Before
     public void before() throws Exception {
         init();
-        localRepoMock = new LocalRepoMock(false);
+        localRepoMock = new LocalRepoMock(temporaryFolder.getRoot(), false);
     }
 
     protected void init() {
         staticLoggerBinder = new StaticLoggerBinder(new ConsoleLoggerManager().getLoggerForComponent("Test"));
         resetConsoleOut();
         resetProperties();
-    }
-
-    protected LocalRepoMock getLocalRepoMock() {
-        return localRepoMock;
     }
 
     private void resetConsoleOut() {
@@ -56,4 +61,13 @@ public abstract class RepoTest {
         System.setOut(normalOut);
         normalOut.print(consoleOut.toString());
     }
+
+    protected LocalRepoMock getLocalRepoMock() {
+        return localRepoMock;
+    }
+
+    protected MavenSession getMavenSessionMock() throws Exception {
+        return MavenSessionMock.get(localRepoMock.getBaseCanonicalBaseFolder().toPath());
+    }
+
 }

--- a/src/test/java/com/vackosar/gitflowincrementalbuild/boundary/IT.java
+++ b/src/test/java/com/vackosar/gitflowincrementalbuild/boundary/IT.java
@@ -1,7 +1,7 @@
 package com.vackosar.gitflowincrementalbuild.boundary;
 
 import com.vackosar.gitflowincrementalbuild.control.Property;
-import com.vackosar.gitflowincrementalbuild.mocks.RepoTest;
+import com.vackosar.gitflowincrementalbuild.BaseRepoTest;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.ResetCommand;
 import org.junit.Assert;
@@ -17,7 +17,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public class IT extends RepoTest {
+public class IT extends BaseRepoTest {
 
     @Test
     public void worktreeFails() throws Exception {

--- a/src/test/java/com/vackosar/gitflowincrementalbuild/boundary/MavenLifecycleParticipantTest.java
+++ b/src/test/java/com/vackosar/gitflowincrementalbuild/boundary/MavenLifecycleParticipantTest.java
@@ -1,8 +1,7 @@
 package com.vackosar.gitflowincrementalbuild.boundary;
 
 import com.vackosar.gitflowincrementalbuild.control.Property;
-import com.vackosar.gitflowincrementalbuild.mocks.MavenSessionMock;
-import com.vackosar.gitflowincrementalbuild.mocks.RepoTest;
+import com.vackosar.gitflowincrementalbuild.BaseRepoTest;
 import org.apache.maven.execution.MavenSession;
 import org.codehaus.plexus.logging.Logger;
 import org.junit.Assert;
@@ -14,34 +13,37 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 
-public class MavenLifecycleParticipantTest extends RepoTest {
+public class MavenLifecycleParticipantTest extends BaseRepoTest {
 
-    @Test public void disabled() throws Exception {
+    @Test
+    public void disabled() throws Exception {
         Property.enabled.setValue("false");
         MavenLifecycleParticipant participant = new MavenLifecycleParticipant();
         Field loggerField = participant.getClass().getDeclaredField("logger");
         loggerField.setAccessible(true);
         loggerField.set(participant, mock(Logger.class));
-        participant.afterProjectsRead(MavenSessionMock.get());
+        participant.afterProjectsRead(getMavenSessionMock());
     }
 
-    @Test public void disabledOverridingPom() throws Exception {
+    @Test
+    public void disabledOverridingPom() throws Exception {
         Property.enabled.setValue("false");
         MavenLifecycleParticipant participant = new MavenLifecycleParticipant();
         Field loggerField = participant.getClass().getDeclaredField("logger");
         loggerField.setAccessible(true);
         loggerField.set(participant, mock(Logger.class));
-        MavenSession session = MavenSessionMock.get();
+        MavenSession session = getMavenSessionMock();
         session.getTopLevelProject().getProperties().setProperty(Property.enabled.fullName(), "true");
         participant.afterProjectsRead(session);
     }
 
-    @Test public void disabledInPom() throws Exception {
+    @Test
+    public void disabledInPom() throws Exception {
         MavenLifecycleParticipant participant = new MavenLifecycleParticipant();
         Field loggerField = participant.getClass().getDeclaredField("logger");
         loggerField.setAccessible(true);
         loggerField.set(participant, mock(Logger.class));
-        MavenSession session = MavenSessionMock.get();
+        MavenSession session = getMavenSessionMock();
         session.getTopLevelProject().getProperties().setProperty(Property.enabled.fullName(), "false");
         participant.afterProjectsRead(session);
     }
@@ -55,7 +57,7 @@ public class MavenLifecycleParticipantTest extends RepoTest {
         loggerField.set(participant, logger);
         StringBuilder builder = new StringBuilder();
         doAnswer(invocation -> builder.append(invocation.getArguments()[0]).append("\n")).when(logger).info(anyString());
-        MavenSession session = MavenSessionMock.get();
+        MavenSession session = getMavenSessionMock();
         participant.afterProjectsRead(session);
         Assert.assertTrue(builder.toString().contains("gitflow-incremental-builder starting..."));
     }

--- a/src/test/java/com/vackosar/gitflowincrementalbuild/control/ChangedProjectsTest.java
+++ b/src/test/java/com/vackosar/gitflowincrementalbuild/control/ChangedProjectsTest.java
@@ -2,9 +2,7 @@ package com.vackosar.gitflowincrementalbuild.control;
 
 import com.google.inject.Guice;
 import com.vackosar.gitflowincrementalbuild.boundary.GuiceModule;
-import com.vackosar.gitflowincrementalbuild.mocks.LocalRepoMock;
-import com.vackosar.gitflowincrementalbuild.mocks.MavenSessionMock;
-import com.vackosar.gitflowincrementalbuild.mocks.RepoTest;
+import com.vackosar.gitflowincrementalbuild.BaseRepoTest;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.logging.console.ConsoleLogger;
 import org.junit.Assert;
@@ -18,7 +16,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public class ChangedProjectsTest extends RepoTest {
+public class ChangedProjectsTest extends BaseRepoTest {
 
     @Test
     public void list() throws Exception {
@@ -28,9 +26,13 @@ public class ChangedProjectsTest extends RepoTest {
                 Paths.get("child4"),
                 Paths.get("testJarDependent")
         ));
-        final Set<Path> actual = Guice.createInjector(new GuiceModule(new ConsoleLogger(), MavenSessionMock.get()))
+        final Set<Path> actual = Guice.createInjector(new GuiceModule(new ConsoleLogger(), getMavenSessionMock()))
                 .getInstance(ChangedProjects.class).get().stream()
-                .map(MavenProject::getBasedir).map(File::toPath).map(LocalRepoMock.WORK_DIR.resolve("parent")::relativize).collect(Collectors.toSet());
+                .map(MavenProject::getBasedir)
+                    .map(File::toPath)
+                    .map(localRepoMock.getBaseCanonicalBaseFolder().toPath().resolve("parent")::relativize)
+                .collect(Collectors.toSet());
         Assert.assertEquals(expected, actual);
     }
+
 }

--- a/src/test/java/com/vackosar/gitflowincrementalbuild/control/PropertyTest.java
+++ b/src/test/java/com/vackosar/gitflowincrementalbuild/control/PropertyTest.java
@@ -4,7 +4,8 @@ import org.junit.Test;
 
 public class PropertyTest {
 
-    @Test public void exemplifyAll() {
+    @Test
+    public void exemplifyAll() {
         System.out.println(Property.exemplifyAll());
     }
 }

--- a/src/test/java/com/vackosar/gitflowincrementalbuild/mocks/LocalRepoMock.java
+++ b/src/test/java/com/vackosar/gitflowincrementalbuild/mocks/LocalRepoMock.java
@@ -11,25 +11,23 @@ import org.eclipse.jgit.transport.URIish;
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 
 public class LocalRepoMock implements AutoCloseable {
 
-    public static final Path TEST_WORK_DIR = Paths.get(System.getProperty("user.dir"));
-    public static final Path WORK_DIR = TEST_WORK_DIR.resolve("tmp/repo/");
-    private static final File REPO = WORK_DIR.toFile();
-    private static final File ZIP = TEST_WORK_DIR.resolve("src/test/resources/template.zip").toFile();
-    private RemoteRepoMock remoteRepo = new RemoteRepoMock(false);
+    private File baseFolder;
+    private File templateProjectZip = new File(getClass().getClassLoader().getResource("template.zip").getFile());
+    private RemoteRepoMock remoteRepo;
     private Git git;
 
-    public LocalRepoMock(boolean remote) throws IOException, URISyntaxException, GitAPIException {
-        delete(REPO);
-        new UnZiper().act(ZIP, REPO);
-        git = new Git(new FileRepository(new File(WORK_DIR + "/.git")));
-        if (remote) {
-            configureRemote(remoteRepo.repoUrl);
-            git.fetch().call();
+    public LocalRepoMock(File baseFolder, boolean withRemote) throws IOException, URISyntaxException, GitAPIException {
+        this.baseFolder = new File(baseFolder.getAbsolutePath(), "tmp/repo/");
+        new UnZipper().act(templateProjectZip, this.baseFolder);
+
+        remoteRepo = new RemoteRepoMock(baseFolder, false);
+        git = new Git(new FileRepository(new File(this.baseFolder, ".git")));
+
+        if (withRemote) {
+            configureRemote(git, remoteRepo.repoUrl);
         }
     }
 
@@ -37,7 +35,7 @@ public class LocalRepoMock implements AutoCloseable {
         return git;
     }
 
-    private void configureRemote(String repoUrl) throws URISyntaxException, IOException, GitAPIException {
+    private void configureRemote(Git git, String repoUrl) throws URISyntaxException, IOException, GitAPIException {
         StoredConfig config = git.getRepository().getConfig();
         config.clear();
         config.setString("remote", "origin" ,"fetch", "+refs/heads/*:refs/remotes/origin/*");
@@ -45,37 +43,31 @@ public class LocalRepoMock implements AutoCloseable {
         config.setString("branch", "master", "remote", "origin");
         config.setString("baseBranch", "master", "merge", "refs/heads/master");
         config.setString("push", null, "default", "current");
+
         RemoteConfig remoteConfig = new RemoteConfig(config, "origin");
         URIish uri = new URIish(repoUrl);
         remoteConfig.addURI(uri);
         remoteConfig.addFetchRefSpec(new RefSpec("refs/heads/master:refs/heads/master"));
         remoteConfig.addPushRefSpec(new RefSpec("refs/heads/master:refs/heads/master"));
         remoteConfig.update(config);
+
         config.save();
         git.fetch().call();
     }
 
-
+    @Override
     public void close() throws Exception {
         remoteRepo.close();
         git.getRepository().close();
         git.close();
-        delete(REPO);
-    }
-
-    private void delete(File f) {
-        if (f.isDirectory()) {
-            for (File c : f.listFiles()) {
-                delete(c);
-            }
-        }
-        if (!f.delete()) {
-            System.out.println("Failed to delete file or directory: " + f + " in LocalRepoMock.delete");
-        }
     }
 
     public RemoteRepoMock getRemoteRepo() {
         return remoteRepo;
+    }
+
+    public File getBaseCanonicalBaseFolder() throws IOException {
+        return baseFolder.getCanonicalFile();
     }
 
 }

--- a/src/test/java/com/vackosar/gitflowincrementalbuild/mocks/MavenSessionMock.java
+++ b/src/test/java/com/vackosar/gitflowincrementalbuild/mocks/MavenSessionMock.java
@@ -21,14 +21,11 @@ import static org.mockito.Mockito.when;
 
 public class MavenSessionMock {
 
-    public static MavenSession get() throws Exception {
-        return get(LocalRepoMock.WORK_DIR);
-    }
-
     public static MavenSession get(Path workDir) throws Exception {
         PomFinder finder = new PomFinder();
         Files.walkFileTree(workDir, finder);
         List<MavenProject> projects = finder.projects.stream().map(MavenSessionMock::createProject).collect(Collectors.toList());
+
         MavenSession mavenSession = mock(MavenSession.class);
         when(mavenSession.getCurrentProject()).thenReturn(projects.get(0));
         MavenExecutionRequest request = mock(MavenExecutionRequest.class);

--- a/src/test/java/com/vackosar/gitflowincrementalbuild/mocks/UnZipper.java
+++ b/src/test/java/com/vackosar/gitflowincrementalbuild/mocks/UnZipper.java
@@ -4,7 +4,7 @@ import java.io.*;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
-public class UnZiper {
+public class UnZipper {
 
     public void act(File zip, File outputFolder){
         try{
@@ -13,7 +13,7 @@ public class UnZiper {
                 process(outputFolder, zis);
                 zis.closeEntry();
             }
-        }catch(IOException e){
+        } catch (IOException e){
             throw new RuntimeException(e);
         }
     }
@@ -22,7 +22,7 @@ public class UnZiper {
         ZipEntry ze = zis.getNextEntry();
         while(ze != null){
             String fileName = ze.getName();
-            File newFile = new File(outputFolder.getPath() + File.separator + fileName);
+            File newFile = new File(outputFolder, fileName);
             createParentDirectories(newFile);
             if (ze.isDirectory()) {
                 newFile.mkdir();


### PR DESCRIPTION
The aim of this PR is to allow HEAD^1 syntax configuring referenceBranch option. This will allow using extension on a CI comparing changes between latest and pre-latest commits.