### PR TITLE
Validating the only current project when no changes are found

### DIFF
--- a/src/main/java/com/vackosar/gitflowincrementalbuild/boundary/UnchangedProjectsRemover.java
+++ b/src/main/java/com/vackosar/gitflowincrementalbuild/boundary/UnchangedProjectsRemover.java
@@ -39,7 +39,8 @@ class UnchangedProjectsRemover {
         if (!configuration.buildAll) {
             Set<MavenProject> rebuild = getRebuildProjects(impacted);
             if (rebuild.isEmpty()) {
-                logger.info("No changed artifacts to build. Executing validate goal only.");
+                logger.info("No changed artifacts to build. Executing validate goal on current project only.");
+                mavenSession.setProjects(Collections.singletonList(mavenSession.getCurrentProject()));
                 mavenSession.getGoals().clear();
                 mavenSession.getGoals().add("validate");
             } else {
@@ -83,8 +84,7 @@ class UnchangedProjectsRemover {
         return mavenProject.getBuildPlugins().stream()
                 .flatMap(p -> p.getExecutions().stream())
                 .flatMap(e -> e.getGoals().stream())
-                .filter(GOAL_TEST_JAR::equals).findAny()
-                .isPresent();
+                .anyMatch(GOAL_TEST_JAR::equals);
     }
 
     private void logProjects(Set<MavenProject> projects, String title) {

--- a/src/test/java/com/vackosar/gitflowincrementalbuild/boundary/MavenInstallRunningIntegrationTest.java
+++ b/src/test/java/com/vackosar/gitflowincrementalbuild/boundary/MavenInstallRunningIntegrationTest.java
@@ -84,18 +84,16 @@ public class MavenInstallRunningIntegrationTest extends BaseRepoTest {
         git.reset().setMode(ResetCommand.ResetType.HARD).setRef("HEAD").call();
         git.checkout().setName("develop").call();
         final String output = executeBuild(Collections.singletonList("-Dgib." + Property.baseBranch.name() + "=refs/heads/develop"));
-        System.out.println(output);
-
-        Assert.assertTrue(output.contains("Executing validate goal only."));
+        Assert.assertTrue(output.contains("Executing validate goal on current project only."));
         Assert.assertTrue(output.contains(" child1"));
-        Assert.assertTrue(output.contains(" child2"));
-        Assert.assertTrue(output.contains(" subchild1"));
-        Assert.assertTrue(output.contains(" subchild42"));
-        Assert.assertTrue(output.contains(" subchild2"));
-        Assert.assertTrue(output.contains(" child3"));
-        Assert.assertTrue(output.contains(" child4"));
-        Assert.assertTrue(output.contains(" subchild41"));
-        Assert.assertTrue(output.contains(" child6"));
+        Assert.assertFalse(output.contains(" child2"));
+        Assert.assertFalse(output.contains(" subchild1"));
+        Assert.assertFalse(output.contains(" subchild42"));
+        Assert.assertFalse(output.contains(" subchild2"));
+        Assert.assertFalse(output.contains(" child3"));
+        Assert.assertFalse(output.contains(" child4"));
+        Assert.assertFalse(output.contains(" subchild41"));
+        Assert.assertFalse(output.contains(" child6"));
     }
 
 


### PR DESCRIPTION
This PR aims to allow the tool to only validate the current maven project when no changed artifacts are found. I found this useful when building some huge multi-module projects. Validating the whole list of projects is somehow wasting time. 
Thanks.