### PR TITLE
Fix issue #28: Introduce gib.disableBranchComparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Maven pom properties configuration with default values is below:
 <properties>
 	<gib.enabled>true</gib.enabled>
 	<gib.repositorySshKey></gib.repositorySshKey>
+	<gib.disableBranchComparison>false</gib.disableBranchComparison>
 	<gib.referenceBranch>refs/remotes/origin/develop</gib.referenceBranch>
 	<gib.baseBranch>HEAD</gib.baseBranch>
 	<gib.uncommited>true</gib.uncommited>
@@ -225,6 +226,15 @@ Maven pom properties configuration with default values is below:
 	<gib.failOnError>true</gib.failOnError>
 </properties>
 ```
+
+### gib.disableBranchComparison
+
+Disables the comparison between `baseBranch` and `referenceBranch`. This property should be enabled if _only_ uncommitted and/or untracked files shall be detected to only build projects that have been changed since the last commit in the current branch (see `gib.uncommited` and `gib.untracked`).
+The following properties are _not_ evaluated when `gib.disableBranchDiff` is enabled:
+ - `gib.referenceBranch`
+ - `gib.compareToMergeBase`
+ - `gib.fetchReferenceBranch`
+ - `gib.excludePathRegex`
 
 ### gib.uncommited
 

--- a/src/main/java/com/vackosar/gitflowincrementalbuild/boundary/Configuration.java
+++ b/src/main/java/com/vackosar/gitflowincrementalbuild/boundary/Configuration.java
@@ -22,6 +22,7 @@ public class Configuration {
 
     public final boolean enabled;
     public final Optional<Path> key;
+    public final boolean disableBranchComparison;
     public final String referenceBranch;
     public String baseBranch;
     public final boolean uncommited;
@@ -41,6 +42,7 @@ public class Configuration {
             checkProperties();
             enabled = Boolean.valueOf(Property.enabled.getValue());
             key = parseKey(session);
+            disableBranchComparison = Boolean.valueOf(Property.disableBranchComparison.getValue());
             referenceBranch = Property.referenceBranch.getValue();
             baseBranch = Property.baseBranch.getValue();
             uncommited = Boolean.valueOf(Property.uncommited.getValue());

--- a/src/main/java/com/vackosar/gitflowincrementalbuild/control/Property.java
+++ b/src/main/java/com/vackosar/gitflowincrementalbuild/control/Property.java
@@ -3,6 +3,7 @@ package com.vackosar.gitflowincrementalbuild.control;
 public enum Property {
     enabled("true"),
     repositorySshKey(""),
+    disableBranchComparison("false"),
     referenceBranch("refs/remotes/origin/develop"),
     baseBranch("HEAD"),
     uncommited("true"),

--- a/src/test/java/com/vackosar/gitflowincrementalbuild/control/DifferentFilesTest.java
+++ b/src/test/java/com/vackosar/gitflowincrementalbuild/control/DifferentFilesTest.java
@@ -35,6 +35,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -162,6 +163,15 @@ public class DifferentFilesTest extends BaseRepoTest {
                 Paths.get(workDir + "/parent/testJarDependent/src/resources/file5")
         ));
         Assert.assertEquals(expected, differentFiles.get());
+    }
+
+    @Test
+    public void listWithDisabledBranchComparison() throws Exception {
+        Property.disableBranchComparison.setValue(Boolean.TRUE.toString());
+
+        final DifferentFiles differentFiles = getInstance(localRepoMock.getBaseCanonicalBaseFolder().toPath());
+
+        Assert.assertEquals(Collections.emptySet(), differentFiles.get());
     }
 
     @Test


### PR DESCRIPTION
Disables the comparison between base and reference branch.