### PR TITLE
Fix issue #57 by selecting proper toplevel project

### DIFF
--- a/src/test/java/com/vackosar/gitflowincrementalbuild/BaseRepoTest.java
+++ b/src/test/java/com/vackosar/gitflowincrementalbuild/BaseRepoTest.java
@@ -57,7 +57,9 @@ public abstract class BaseRepoTest {
 
     @After
     public void after() throws Exception {
-        localRepoMock.close();
+        if (localRepoMock != null) {
+            localRepoMock.close();
+        }
         System.setOut(normalOut);
         normalOut.print(consoleOut.toString());
     }

--- a/src/test/java/com/vackosar/gitflowincrementalbuild/mocks/MavenSessionMock.java
+++ b/src/test/java/com/vackosar/gitflowincrementalbuild/mocks/MavenSessionMock.java
@@ -25,7 +25,10 @@ public class MavenSessionMock {
     public static MavenSession get(Path workDir) throws Exception {
         PomFinder finder = new PomFinder();
         Files.walkFileTree(workDir, finder);
-        List<MavenProject> projects = finder.projects.stream().map(MavenSessionMock::createProject).collect(Collectors.toList());
+        List<MavenProject> projects = finder.projects.stream()
+                .sorted()
+                .map(MavenSessionMock::createProject)
+                .collect(Collectors.toList());
 
         MavenSession mavenSession = mock(MavenSession.class);
         when(mavenSession.getCurrentProject()).thenReturn(projects.get(0));


### PR DESCRIPTION
See PR #58 for details.
Also added small fix to BaseRepoTest to avoid NPE
when localRepoMock could be created.