### PR TITLE
Fix issue #66: Regex-support for forceBuildModules

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,10 @@ Defines artifact ids of modules to build forcibly, even if these modules have no
 ```
 mvn clean install -Dgib.forceBuildModules=unchanged-module-1,unchanged-module-2
 ```
+Regular expressions are also supported in each comma separated part, e.g.:
+```
+mvn clean install -Dgib.forceBuildModules=unchanged-module-.*,another-module
+```
 Each of these modules is subject to `argsForNotImpactedModules` and `skipTestsForNotImpactedModules`.
 
 This property has no effect in case `buildAll` is enabled.

--- a/src/main/java/com/vackosar/gitflowincrementalbuild/boundary/UnchangedProjectsRemover.java
+++ b/src/main/java/com/vackosar/gitflowincrementalbuild/boundary/UnchangedProjectsRemover.java
@@ -10,6 +10,7 @@ import org.eclipse.jgit.api.errors.GitAPIException;
 import javax.inject.Inject;
 import java.io.IOException;
 import java.util.*;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -51,7 +52,7 @@ class UnchangedProjectsRemover {
                 mavenSession.getGoals().add("validate");
             } else if (!configuration.forceBuildModules.isEmpty()) {
                 Stream<MavenProject> forceBuildModules = mavenSession.getProjects().stream()
-                        .filter(p -> configuration.forceBuildModules.contains(p.getArtifactId()))
+                        .filter(p -> matchesAny(p.getArtifactId(), configuration.forceBuildModules))
                         .filter(p -> !rebuild.contains(p))
                         .map(this::applyNotImpactedModuleArgs);
                 mavenSession.setProjects(
@@ -125,6 +126,10 @@ class UnchangedProjectsRemover {
         return Stream.concat(
             Stream.of(project),
             mavenSession.getProjectDependencyGraph().getUpstreamProjects(project, true).stream());
+    }
+
+    private boolean matchesAny(final String str, Collection<Pattern> patterns) {
+        return patterns.stream().anyMatch(pattern -> pattern.matcher(str).matches());
     }
 }
 

--- a/src/test/java/com/vackosar/gitflowincrementalbuild/boundary/ConfigurationTest.java
+++ b/src/test/java/com/vackosar/gitflowincrementalbuild/boundary/ConfigurationTest.java
@@ -1,0 +1,128 @@
+package com.vackosar.gitflowincrementalbuild.boundary;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.Arrays;
+import java.util.Properties;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+import org.apache.maven.execution.MavenExecutionRequest;
+import org.apache.maven.execution.MavenSession;
+import org.hamcrest.core.IsInstanceOf;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.RuleChain;
+import org.junit.runner.RunWith;
+import org.junit.runners.model.Statement;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.google.common.collect.ImmutableMap;
+import com.vackosar.gitflowincrementalbuild.control.Property;
+
+/**
+ * Tests the system properties parsing logic in {@link Configuration}.
+ *
+ * @author famod
+ *
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ConfigurationTest {
+
+    private final ExpectedException thrown = ExpectedException.none();
+
+    @Rule
+    public final RuleChain ruleChain = RuleChain
+            // properly reset system properties after each test
+            .outerRule((base, description) -> new Statement() {
+                @Override
+                public void evaluate() throws Throwable {
+                    final Properties backup = (Properties) System.getProperties().clone();
+                    try {
+                        base.evaluate();
+                    } finally {
+                        System.setProperties(backup);
+                    }
+                }
+            })
+            .around(thrown);
+
+    @Mock
+    private MavenExecutionRequest mavenExecutionRequestMock;
+
+    @Mock
+    private MavenSession mavenSessioMock;
+
+    @Before
+    public void setup() {
+        Mockito.when(mavenSessioMock.getRequest()).thenReturn(mavenExecutionRequestMock);
+    }
+
+    @Test
+    public void invalidProperty() {
+        String invalidProperty = Property.PREFIX + "invalid";
+        System.setProperty(invalidProperty, "invalid");
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage(invalidProperty);
+        thrown.expectMessage(Property.disableBranchComparison.fullName());  // just one of those valid ones
+
+        new Configuration(mavenSessioMock);
+    }
+
+    @Test
+    public void enabled() {
+        System.setProperty(Property.enabled.fullName(), "false");
+
+        Configuration configuration = new Configuration(mavenSessioMock);
+
+        assertFalse(configuration.enabled);
+    }
+
+    @Test
+    public void argsForNotImpactedModules() {
+        System.setProperty(Property.argsForNotImpactedModules.fullName(), "x=true a=false");
+
+        Configuration configuration = new Configuration(mavenSessioMock);
+
+        assertEquals(ImmutableMap.of("x", "true", "a", "false"), configuration.argsForNotImpactedModules);
+    }
+
+    @Test
+    public void excludeTransitiveModulesPackagedAs() {
+        System.setProperty(Property.excludeTransitiveModulesPackagedAs.fullName(), "ear,war");
+
+        Configuration configuration = new Configuration(mavenSessioMock);
+
+        assertEquals(Arrays.asList("ear", "war"), configuration.excludeTransitiveModulesPackagedAs);
+    }
+
+    @Test
+    public void forceBuildModules_pattern() {
+        String expectedPatternString = ".*-some-artifact";
+        System.setProperty(Property.forceBuildModules.fullName(), expectedPatternString);
+
+        Configuration configuration = new Configuration(mavenSessioMock);
+
+        assertNotNull("Field forceBuildModules is null", configuration.forceBuildModules);
+        assertEquals("Unexpected number of Patterns in forceBuildModules", 1, configuration.forceBuildModules.size());
+        Pattern pattern = configuration.forceBuildModules.get(0);
+        assertNotNull("Pattern form forceBuildModules is null", pattern);
+        assertEquals("Unexpected pattern string of Pattern from forceBuildModules", expectedPatternString, pattern.pattern());
+    }
+
+    @Test
+    public void forceBuildModules_patternInvalid() {
+        System.setProperty(Property.forceBuildModules.fullName(), "*-some-artifact");   // pattern is missing the dot
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage(Property.forceBuildModules.fullName());
+        thrown.expectCause(IsInstanceOf.instanceOf(PatternSyntaxException.class));
+
+        new Configuration(mavenSessioMock);
+    }
+}


### PR DESCRIPTION
The value is still first split by "," but then each part
is compiled to a java.util.Pattern.

Additional changes:
- cleaned up exception handling in Configuration, also to
  provide more context for the user
- introduced dedicated test for Configuration
  (which does not yet cover all cases but it is a start)
- removed toRealPath() in Configuration.parseKey()
  (to align with PR #63)