### PR TITLE
Verify JDK8 API compatibility via animal-sniffer-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,7 @@
         <version.nexus-staging-maven-plugin>1.6.8</version.nexus-staging-maven-plugin>
         <version.versions-maven-plugin>2.7</version.versions-maven-plugin>
         <version.maven-release-plugin>3.0.0-M1</version.maven-release-plugin>
+        <version.animal-sniffer-maven-plugin>1.18</version.animal-sniffer-maven-plugin>
 
         <gibIntegrationTestRepo>${project.build.directory}${file.separator}it${file.separator}repo</gibIntegrationTestRepo>
 
@@ -321,6 +322,11 @@
                         <goals>deploy</goals>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>animal-sniffer-maven-plugin</artifactId>
+                    <version>${version.animal-sniffer-maven-plugin}</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -459,6 +465,37 @@
         </plugins>
     </build>
     <profiles>
+        <!-- verify that only JDK8 APIs are used -->
+        <profile>
+            <id>jdk9+</id>
+            <activation>
+                <jdk>[1.9,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>animal-sniffer-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>check-java-version-compatibility</id>
+                                <phase>test</phase>
+                                <goals>
+                                   <goal>check</goal>
+                                </goals>
+                                <configuration>
+                                    <signature>
+                                        <groupId>org.codehaus.mojo.signature</groupId>
+                                        <artifactId>java18</artifactId>
+                                        <version>1.0</version>
+                                    </signature>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <!-- avoid to clean the integration test repo in target, unless executed with -DcleanAll -->
         <profile>
             <id>dont-clean-it-repo</id>


### PR DESCRIPTION
To have an early local feedback (before any Travis builds).