### PR TITLE
Introduce SpotBugs and fix findings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,8 @@
         <version.versions-maven-plugin>2.7</version.versions-maven-plugin>
         <version.maven-release-plugin>3.0.0-M1</version.maven-release-plugin>
         <version.animal-sniffer-maven-plugin>1.18</version.animal-sniffer-maven-plugin>
+        <version.spotbugs-maven-plugin>3.1.12.2</version.spotbugs-maven-plugin>
+        <version.spotbugs>4.0.0</version.spotbugs>
 
         <gibIntegrationTestRepo>${project.build.directory}${file.separator}it${file.separator}repo</gibIntegrationTestRepo>
 
@@ -373,6 +375,19 @@
                     <artifactId>animal-sniffer-maven-plugin</artifactId>
                     <version>${version.animal-sniffer-maven-plugin}</version>
                 </plugin>
+                <plugin>
+                    <groupId>com.github.spotbugs</groupId>
+                    <artifactId>spotbugs-maven-plugin</artifactId>
+                    <version>${version.spotbugs-maven-plugin}</version>
+                    <dependencies>
+                        <!-- overwrite dependency on spotbugs if you want to specify the version of spotbugs -->
+                        <dependency>
+                            <groupId>com.github.spotbugs</groupId>
+                            <artifactId>spotbugs</artifactId>
+                            <version>${version.spotbugs}</version>
+                        </dependency>
+                    </dependencies>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -504,6 +519,18 @@
                         <goals>
                             <goal>integration-test</goal>
                             <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>spotbugs-check</id>
+                        <goals>
+                            <goal>check</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/src/main/java/com/vackosar/gitflowincrementalbuild/boundary/Configuration.java
+++ b/src/main/java/com/vackosar/gitflowincrementalbuild/boundary/Configuration.java
@@ -130,7 +130,7 @@ public class Configuration {
                 .collect(Collectors.joining("\n\t"));
         if (!invalidPropertyNames.isEmpty()) {
             throw new IllegalArgumentException(
-                    String.format("Invalid GIB properties found:\n\t%s\nAllowed properties:\n%s", invalidPropertyNames, Property.exemplifyAll()));
+                    String.format("Invalid GIB properties found:%n\t%s%nAllowed properties:%n%s", invalidPropertyNames, Property.exemplifyAll()));
         }
     }
 

--- a/src/main/java/com/vackosar/gitflowincrementalbuild/control/DifferentFiles.java
+++ b/src/main/java/com/vackosar/gitflowincrementalbuild/control/DifferentFiles.java
@@ -33,6 +33,8 @@ import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -110,9 +112,12 @@ public class DifferentFiles {
     }
 
     private boolean isWorktree(FileRepositoryBuilder builder) {
-        Path gitDirParent = builder.getGitDir().toPath().getParent();
-        return gitDirParent.getFileName().toString().equals("worktrees")
-                && gitDirParent.getParent().getFileName().toString().equals(".git");
+        return Optional.ofNullable(builder.getGitDir().toPath().getParent())
+                .filter(parent -> parent.getFileName().toString().equals("worktrees"))
+                .map(Path::getParent)
+                .filter(Objects::nonNull)
+                .map(parentParent -> parentParent.getFileName().toString().equals(".git"))
+                .orElse(false);
     }
 
     private class Worker {

--- a/src/main/java/com/vackosar/gitflowincrementalbuild/control/jgit/HttpDelegatingCredentialsProvider.java
+++ b/src/main/java/com/vackosar/gitflowincrementalbuild/control/jgit/HttpDelegatingCredentialsProvider.java
@@ -3,6 +3,7 @@ package com.vackosar.gitflowincrementalbuild.control.jgit;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -125,7 +126,7 @@ public class HttpDelegatingCredentialsProvider extends CredentialsProvider {
         }
         procBuilder.directory(projectDir.toFile());
 
-        ExecutionResult result = fs.execute(procBuilder, new ByteArrayInputStream(buildGitCommandInput(uri).getBytes()));
+        ExecutionResult result = fs.execute(procBuilder, new ByteArrayInputStream(buildGitCommandInput(uri).getBytes(Charset.defaultCharset())));
         if (result.getRc() != 0) {
             logger.info(bufferToString(result.getStdout()));
             logger.error(bufferToString(result.getStderr()));
@@ -156,7 +157,7 @@ public class HttpDelegatingCredentialsProvider extends CredentialsProvider {
     private String bufferToString(TemporaryBuffer buffer) throws IOException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         buffer.writeTo(baos, null);
-        return baos.toString();
+        return baos.toString(Charset.defaultCharset().name());
     }
 
     private CredentialsPair extractCredentials(String nativeGitOutput) {
@@ -176,7 +177,7 @@ public class HttpDelegatingCredentialsProvider extends CredentialsProvider {
         return credPair;
     }
 
-    private class CredentialsPair {
+    private static class CredentialsPair {
         private String username;
         private char[] password;
     }


### PR DESCRIPTION
Findings were:
```
[ERROR] Format string should use %n rather than \n in com.vackosar.gitflowincrementalbuild.boundary.Configuration.checkProperties(Properties) [com.vackosar.gitflowincrementalbuild.boundary.Configuration] At Configuration.java:[line 133] VA_FORMAT_STRING_USES_NEWLINE
[ERROR] Possible null pointer dereference in com.vackosar.gitflowincrementalbuild.control.DifferentFiles.isWorktree(FileRepositoryBuilder) due to return value of called method [com.vackosar.gitflowincrementalbuild.control.DifferentFiles, com.vackosar.gitflowincrementalbuild.control.DifferentFiles] Dereferenced at DifferentFiles.java:[line 114]Known null at DifferentFiles.java:[line 114] NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE
[ERROR] Possible null pointer dereference in com.vackosar.gitflowincrementalbuild.control.DifferentFiles.isWorktree(FileRepositoryBuilder) due to return value of called method [com.vackosar.gitflowincrementalbuild.control.DifferentFiles, com.vackosar.gitflowincrementalbuild.control.DifferentFiles] Dereferenced at DifferentFiles.java:[line 115]Known null at DifferentFiles.java:[line 115] NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE
[ERROR] Possible null pointer dereference in com.vackosar.gitflowincrementalbuild.control.DifferentFiles.isWorktree(FileRepositoryBuilder) due to return value of called method [com.vackosar.gitflowincrementalbuild.control.DifferentFiles, com.vackosar.gitflowincrementalbuild.control.DifferentFiles] Dereferenced at DifferentFiles.java:[line 114]Known null at DifferentFiles.java:[line 113] NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE
[ERROR] Found reliance on default encoding in com.vackosar.gitflowincrementalbuild.control.jgit.HttpDelegatingCredentialsProvider.bufferToString(TemporaryBuffer): java.io.ByteArrayOutputStream.toString() [com.vackosar.gitflowincrementalbuild.control.jgit.HttpDelegatingCredentialsProvider] At HttpDelegatingCredentialsProvider.java:[line 159] DM_DEFAULT_ENCODING
[ERROR] Found reliance on default encoding in com.vackosar.gitflowincrementalbuild.control.jgit.HttpDelegatingCredentialsProvider.lookupCredentials(URIish): String.getBytes() [com.vackosar.gitflowincrementalbuild.control.jgit.HttpDelegatingCredentialsProvider] At HttpDelegatingCredentialsProvider.java:[line 128] DM_DEFAULT_ENCODING
[ERROR] Should com.vackosar.gitflowincrementalbuild.control.jgit.HttpDelegatingCredentialsProvider$CredentialsPair be a _static_ inner class? [com.vackosar.gitflowincrementalbuild.control.jgit.HttpDelegatingCredentialsProvider$CredentialsPair] At HttpDelegatingCredentialsProvider.java:[line 179] SIC_INNER_SHOULD_BE_STATIC
```