### PR TITLE
Avoid NPE in IntelliJ IDEA when getting project properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -638,7 +638,7 @@
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.85</minimum>
+                                            <minimum>0.84</minimum>
                                         </limit>
                                         <limit>
                                             <counter>CLASS</counter>

--- a/pom.xml
+++ b/pom.xml
@@ -638,7 +638,7 @@
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.84</minimum>
+                                            <minimum>0.85</minimum>
                                         </limit>
                                         <limit>
                                             <counter>CLASS</counter>

--- a/src/main/java/com/vackosar/gitflowincrementalbuild/boundary/Configuration.java
+++ b/src/main/java/com/vackosar/gitflowincrementalbuild/boundary/Configuration.java
@@ -7,10 +7,6 @@ import org.apache.maven.execution.MavenExecutionRequest;
 import org.apache.maven.execution.MavenSession;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 
-import javax.inject.Inject;
-import javax.inject.Named;
-import javax.inject.Singleton;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.AbstractMap;
@@ -35,6 +31,8 @@ import static java.util.stream.Collectors.toList;
 public class Configuration {
 
     public static final String PLUGIN_KEY = "com.vackosar.gitflowincrementalbuilder:gitflow-incremental-builder";
+
+    public final MavenSession mavenSession;
 
     public final boolean help;
     public final boolean enabled;
@@ -65,7 +63,8 @@ public class Configuration {
     public final boolean failOnError;
     public final Optional<Path> logImpactedTo;
 
-    private Configuration(MavenSession session) {
+    public Configuration(MavenSession session) {
+        this.mavenSession = session;
         Properties projectProperties = getProjectProperties(session);
         Properties pluginProperties = getPluginProperties(session);
 
@@ -249,32 +248,5 @@ public class Configuration {
         NONE,
         CHANGED,
         IMPACTED;
-    }
-
-    @Singleton
-    @Named
-    public static class Provider implements javax.inject.Provider<Configuration> {
-
-        private final MavenSession mavenSession;
-
-        private Configuration configuration;
-
-        @Inject
-        public Provider(MavenSession mavenSession) {
-            this.mavenSession = mavenSession;
-        }
-
-        /**
-         * Returns a {@link Configuration} instance which is constructed when first called. Subsequent calls will return the same instance.
-         *
-         * @return a {@link Configuration} instance
-         */
-        @Override
-        public Configuration get() {
-            if (configuration == null) {
-                configuration = new Configuration(mavenSession);
-            }
-            return configuration;
-        }
     }
 }

--- a/src/main/java/com/vackosar/gitflowincrementalbuild/boundary/Configuration.java
+++ b/src/main/java/com/vackosar/gitflowincrementalbuild/boundary/Configuration.java
@@ -5,7 +5,10 @@ import com.vackosar.gitflowincrementalbuild.control.Property.ValueWithOriginCont
 
 import org.apache.maven.execution.MavenExecutionRequest;
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -63,10 +66,13 @@ public class Configuration {
     public final boolean failOnError;
     public final Optional<Path> logImpactedTo;
 
+    private Logger logger = LoggerFactory.getLogger(Configuration.class);
+
     public Configuration(MavenSession session) {
         this.mavenSession = session;
-        Properties projectProperties = getProjectProperties(session);
-        Properties pluginProperties = getPluginProperties(session);
+        Properties[] properties = getProperties(session, logger);
+        Properties projectProperties = properties[0];
+        Properties pluginProperties = properties[1];
 
         help = Boolean.parseBoolean(Property.help.getValue(pluginProperties, projectProperties));
         enabled = Boolean.parseBoolean(Property.enabled.getValue(pluginProperties, projectProperties));
@@ -167,12 +173,20 @@ public class Configuration {
         return expectedMakeBehavior.equals(actualMakeBehavior) || MavenExecutionRequest.REACTOR_MAKE_BOTH.equals(actualMakeBehavior);
     }
 
-    private static Properties getProjectProperties(MavenSession session) {
-        return session.getTopLevelProject().getProperties();
+    private static Properties[] getProperties(MavenSession session, Logger logger) {
+        MavenProject mavenProject = Optional.ofNullable(session.getTopLevelProject()).orElseGet(session::getCurrentProject);
+        if (mavenProject != null) {
+            return new Properties[] { mavenProject.getProperties(), getPluginProperties(mavenProject) };
+        } else {
+            logger.warn("gitflow-incremental-builder could not parse configuration due to missing 'topLevel' or 'current' project in the MavenSession.");
+            Properties fakeProjectProperties = new Properties();
+            fakeProjectProperties.put(Property.enabled.prefixedName(), Boolean.FALSE.toString());
+            return new Properties[] { fakeProjectProperties, new Properties() };
+        }
     }
 
-    private static Properties getPluginProperties(MavenSession session) {
-        return Optional.ofNullable(session.getTopLevelProject().getPlugin(PLUGIN_KEY))
+    private static Properties getPluginProperties(MavenProject mavenProject) {
+        return Optional.ofNullable(mavenProject.getPlugin(PLUGIN_KEY))
                 .map(plugin -> (Xpp3Dom) plugin.getConfiguration())
                 .map(Xpp3Dom::getChildren)
                 .filter(children -> children.length > 0)

--- a/src/main/java/com/vackosar/gitflowincrementalbuild/control/ChangedProjects.java
+++ b/src/main/java/com/vackosar/gitflowincrementalbuild/control/ChangedProjects.java
@@ -1,10 +1,11 @@
 package com.vackosar.gitflowincrementalbuild.control;
 
-import org.apache.maven.execution.MavenSession;
 import org.apache.maven.project.MavenProject;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.vackosar.gitflowincrementalbuild.boundary.Configuration;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -24,12 +25,11 @@ public class ChangedProjects {
     private Logger logger = LoggerFactory.getLogger(ChangedProjects.class);
 
     @Inject private DifferentFiles differentFiles;
-    @Inject private MavenSession mavenSession;
     @Inject private Modules modules;
 
-    public Set<MavenProject> get() throws GitAPIException, IOException {
-        Map<Path, MavenProject> modulesPathMap = modules.createPathMap(mavenSession);
-        return differentFiles.get().stream()
+    public Set<MavenProject> get(Configuration config) throws GitAPIException, IOException {
+        Map<Path, MavenProject> modulesPathMap = modules.createPathMap(config.mavenSession);
+        return differentFiles.get(config).stream()
                 .map(path -> findProject(path, modulesPathMap))
                 .filter(Objects::nonNull)
                 .collect(Collectors.toSet());

--- a/src/main/java/com/vackosar/gitflowincrementalbuild/control/DifferentFiles.java
+++ b/src/main/java/com/vackosar/gitflowincrementalbuild/control/DifferentFiles.java
@@ -44,25 +44,23 @@ public class DifferentFiles {
 
     private Logger logger = LoggerFactory.getLogger(DifferentFiles.class);
 
-    @Inject private Configuration.Provider configProvider;
     @Inject private GitProvider gitProvider;
 
     private final Map<String, String> additionalNativeGitEnvironment = new HashMap<>();
 
-    public Set<Path> get() throws GitAPIException, IOException {
+    public Set<Path> get(Configuration config) throws GitAPIException, IOException {
         Set<Path> paths = new HashSet<>();
 
-        Configuration configuration = configProvider.get();
         Worker worker = null;
         try {
-            worker = new Worker(gitProvider.get(), configuration);
+            worker = new Worker(gitProvider.get(config), config);
 
             worker.fetch();
             worker.checkout();
-            if (!configuration.disableBranchComparison) {
+            if (!config.disableBranchComparison) {
                 paths.addAll(worker.getBranchDiff());
             }
-            if (configuration.uncommited || configuration.untracked) {
+            if (config.uncommited || config.untracked) {
                 paths.addAll(worker.getChangesFromStatus());
             }
         } finally {

--- a/src/test/java/com/vackosar/gitflowincrementalbuild/boundary/BaseUnchangedProjectsRemoverTest.java
+++ b/src/test/java/com/vackosar/gitflowincrementalbuild/boundary/BaseUnchangedProjectsRemoverTest.java
@@ -1,6 +1,7 @@
 package com.vackosar.gitflowincrementalbuild.boundary;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
@@ -28,8 +29,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.powermock.reflect.Whitebox;
-
 import com.vackosar.gitflowincrementalbuild.control.ChangedProjects;
 import com.vackosar.gitflowincrementalbuild.control.Property;
 
@@ -92,11 +91,9 @@ public abstract class BaseUnchangedProjectsRemoverTest {
         when(mavenSessionMock.getRequest()).thenReturn(mavenExecutionRequestMock);
         when(mavenSessionMock.getProjects()).thenReturn(projects);
         when(mavenSessionMock.getProjectDependencyGraph()).thenReturn(projectDependencyGraphMock);
-        when(changedProjectsMock.get()).thenReturn(changedProjects);
+        when(changedProjectsMock.get(any(Configuration.class))).thenReturn(changedProjects);
 
         when(mavenSessionMock.getGoals()).thenReturn(new ArrayList<>());
-
-        Whitebox.setInternalState(underTest, new Configuration.Provider(mavenSessionMock));
     }
 
     protected MavenProject addModuleMock(String moduleArtifactId, boolean addToChanged) {
@@ -166,5 +163,9 @@ public abstract class BaseUnchangedProjectsRemoverTest {
                         (a, b) -> a,
                         TreeMap::new));
         assertEquals(new TreeMap<>(expected), actual, "Unexpected project properties of " + project);
+    }
+
+    protected Configuration config() {
+        return new Configuration(mavenSessionMock);
     }
 }

--- a/src/test/java/com/vackosar/gitflowincrementalbuild/boundary/ConfigurationTest.java
+++ b/src/test/java/com/vackosar/gitflowincrementalbuild/boundary/ConfigurationTest.java
@@ -66,7 +66,7 @@ public class ConfigurationTest {
         String invalidProperty = Property.PREFIX + "invalid";
         System.setProperty(invalidProperty, "invalid");
 
-        assertThatIllegalArgumentException().isThrownBy(() -> new Configuration.Provider(mavenSessionMock).get())
+        assertThatIllegalArgumentException().isThrownBy(() -> new Configuration(mavenSessionMock))
                 .withMessageContaining(invalidProperty)
                 .withMessageContaining(Property.disableBranchComparison.prefixedName());
     }
@@ -75,7 +75,7 @@ public class ConfigurationTest {
     public void enabled() {
         System.setProperty(Property.enabled.prefixedName(), "false");
 
-        Configuration configuration = new Configuration.Provider(mavenSessionMock).get();
+        Configuration configuration = new Configuration(mavenSessionMock);
 
         assertFalse(configuration.enabled);
         assertNull(configuration.disableIfBranchRegex);
@@ -85,7 +85,7 @@ public class ConfigurationTest {
     public void enabled_projectProperties() {
         projectProperties.put(Property.enabled.prefixedName(), "false");
 
-        Configuration configuration = new Configuration.Provider(mavenSessionMock).get();
+        Configuration configuration = new Configuration(mavenSessionMock);
 
         assertFalse(configuration.enabled);
         assertNull(configuration.disableIfBranchRegex);
@@ -96,7 +96,7 @@ public class ConfigurationTest {
         projectProperties.put(Property.enabled.prefixedName(), "true");
         System.setProperty(Property.enabled.prefixedName(), "false");
 
-        Configuration configuration = new Configuration.Provider(mavenSessionMock).get();
+        Configuration configuration = new Configuration(mavenSessionMock);
 
         assertFalse(configuration.enabled);
         assertNull(configuration.disableIfBranchRegex);
@@ -106,7 +106,7 @@ public class ConfigurationTest {
     public void argsForUpstreamModules() {
         System.setProperty(Property.argsForUpstreamModules.prefixedName(), "x=true a=false");
 
-        Configuration configuration = new Configuration.Provider(mavenSessionMock).get();
+        Configuration configuration = new Configuration(mavenSessionMock);
 
         assertEquals(ImmutableMap.of("x", "true", "a", "false"), configuration.argsForUpstreamModules);
     }
@@ -115,7 +115,7 @@ public class ConfigurationTest {
     public void excludeDownstreamModulesPackagedAs() {
         System.setProperty(Property.excludeDownstreamModulesPackagedAs.prefixedName(), "ear,war");
 
-        Configuration configuration = new Configuration.Provider(mavenSessionMock).get();
+        Configuration configuration = new Configuration(mavenSessionMock);
 
         assertEquals(Arrays.asList("ear", "war"), configuration.excludeDownstreamModulesPackagedAs);
     }
@@ -125,7 +125,7 @@ public class ConfigurationTest {
     public void excludeTransitiveModulesPackagedAs() {
         System.setProperty(Property.excludeDownstreamModulesPackagedAs.deprecatedPrefixedName(), "ear,war");
 
-        Configuration configuration = new Configuration.Provider(mavenSessionMock).get();
+        Configuration configuration = new Configuration(mavenSessionMock);
 
         assertEquals(Arrays.asList("ear", "war"), configuration.excludeDownstreamModulesPackagedAs);
     }
@@ -135,7 +135,7 @@ public class ConfigurationTest {
         String expectedPatternString = ".*-some-artifact";
         System.setProperty(Property.forceBuildModules.prefixedName(), expectedPatternString);
 
-        Configuration configuration = new Configuration.Provider(mavenSessionMock).get();
+        Configuration configuration = new Configuration(mavenSessionMock);
 
         assertNotNull(configuration.forceBuildModules,"Field forceBuildModules is null");
         assertEquals( 1, configuration.forceBuildModules.size(), "Unexpected number of Patterns in forceBuildModules");
@@ -148,7 +148,7 @@ public class ConfigurationTest {
     public void forceBuildModules_patternInvalid() {
         System.setProperty(Property.forceBuildModules.prefixedName(), "*-some-artifact");   // pattern is missing the dot
 
-        assertThatIllegalArgumentException().isThrownBy(() -> new Configuration.Provider(mavenSessionMock).get())
+        assertThatIllegalArgumentException().isThrownBy(() -> new Configuration(mavenSessionMock))
                 .withMessageContaining(Property.forceBuildModules.prefixedName())
                 .withCauseExactlyInstanceOf(PatternSyntaxException.class);
     }
@@ -160,7 +160,7 @@ public class ConfigurationTest {
     public void buildUpstreamMode_never() {
         System.setProperty(Property.buildUpstream.prefixedName(), "never");
 
-        Configuration configuration = new Configuration.Provider(mavenSessionMock).get();
+        Configuration configuration = new Configuration(mavenSessionMock);
 
         assertSame(BuildUpstreamMode.NONE, configuration.buildUpstreamMode);
         verify(mavenExecutionRequestMock, never()).getMakeBehavior();
@@ -170,7 +170,7 @@ public class ConfigurationTest {
     public void buildUpstreamMode_false() {
         System.setProperty(Property.buildUpstream.prefixedName(), "false");
 
-        Configuration configuration = new Configuration.Provider(mavenSessionMock).get();
+        Configuration configuration = new Configuration(mavenSessionMock);
 
         assertSame(BuildUpstreamMode.NONE, configuration.buildUpstreamMode);
         verify(mavenExecutionRequestMock, never()).getMakeBehavior();
@@ -180,7 +180,7 @@ public class ConfigurationTest {
     public void buildUpstreamMode_always() {
         System.setProperty(Property.buildUpstream.prefixedName(), "always");
 
-        Configuration configuration = new Configuration.Provider(mavenSessionMock).get();
+        Configuration configuration = new Configuration(mavenSessionMock);
 
         assertSame(BuildUpstreamMode.CHANGED, configuration.buildUpstreamMode);
         verify(mavenExecutionRequestMock, never()).getMakeBehavior();
@@ -190,7 +190,7 @@ public class ConfigurationTest {
     public void buildUpstreamMode_true() {
         System.setProperty(Property.buildUpstream.prefixedName(), "true");
 
-        Configuration configuration = new Configuration.Provider(mavenSessionMock).get();
+        Configuration configuration = new Configuration(mavenSessionMock);
 
         assertSame(BuildUpstreamMode.CHANGED, configuration.buildUpstreamMode);
         verify(mavenExecutionRequestMock, never()).getMakeBehavior();
@@ -200,7 +200,7 @@ public class ConfigurationTest {
     public void buildUpstreamMode_unknown() {
         System.setProperty(Property.buildUpstream.prefixedName(), "foo");
 
-        assertThatIllegalArgumentException().isThrownBy(() -> new Configuration.Provider(mavenSessionMock).get())
+        assertThatIllegalArgumentException().isThrownBy(() -> new Configuration(mavenSessionMock))
                 .withMessageContaining(Property.buildUpstream.prefixedName());
     }
 
@@ -208,7 +208,7 @@ public class ConfigurationTest {
 
     @Test
     public void buildUpstreamMode_derived_noMake() {
-        Configuration configuration = new Configuration.Provider(mavenSessionMock).get();
+        Configuration configuration = new Configuration(mavenSessionMock);
 
         assertSame(BuildUpstreamMode.NONE, configuration.buildUpstreamMode);
     }
@@ -217,7 +217,7 @@ public class ConfigurationTest {
     public void buildUpstreamMode_derived_makeUpstream() {
         when(mavenExecutionRequestMock.getMakeBehavior()).thenReturn(MavenExecutionRequest.REACTOR_MAKE_UPSTREAM);
 
-        Configuration configuration = new Configuration.Provider(mavenSessionMock).get();
+        Configuration configuration = new Configuration(mavenSessionMock);
 
         assertSame(BuildUpstreamMode.CHANGED, configuration.buildUpstreamMode);
     }
@@ -226,7 +226,7 @@ public class ConfigurationTest {
     public void buildUpstreamMode_derived_makeBoth() {
         when(mavenExecutionRequestMock.getMakeBehavior()).thenReturn(MavenExecutionRequest.REACTOR_MAKE_BOTH);
 
-        Configuration configuration = new Configuration.Provider(mavenSessionMock).get();
+        Configuration configuration = new Configuration(mavenSessionMock);
 
         assertSame(BuildUpstreamMode.CHANGED, configuration.buildUpstreamMode);
     }
@@ -235,7 +235,7 @@ public class ConfigurationTest {
     public void buildUpstreamMode_derived_makeDownstream() {
         when(mavenExecutionRequestMock.getMakeBehavior()).thenReturn(MavenExecutionRequest.REACTOR_MAKE_DOWNSTREAM);
 
-        Configuration configuration = new Configuration.Provider(mavenSessionMock).get();
+        Configuration configuration = new Configuration(mavenSessionMock);
 
         assertSame(BuildUpstreamMode.NONE, configuration.buildUpstreamMode);
     }
@@ -245,7 +245,7 @@ public class ConfigurationTest {
         System.setProperty(Property.buildUpstreamMode.prefixedName(), "impacted");
         when(mavenExecutionRequestMock.getMakeBehavior()).thenReturn(MavenExecutionRequest.REACTOR_MAKE_UPSTREAM);
 
-        Configuration configuration = new Configuration.Provider(mavenSessionMock).get();
+        Configuration configuration = new Configuration(mavenSessionMock);
 
         assertSame(BuildUpstreamMode.IMPACTED, configuration.buildUpstreamMode);
     }
@@ -255,7 +255,7 @@ public class ConfigurationTest {
         System.setProperty(Property.buildUpstreamMode.prefixedName(), "foo");
         when(mavenExecutionRequestMock.getMakeBehavior()).thenReturn(MavenExecutionRequest.REACTOR_MAKE_UPSTREAM);
 
-        assertThatIllegalArgumentException().isThrownBy(() -> new Configuration.Provider(mavenSessionMock).get())
+        assertThatIllegalArgumentException().isThrownBy(() -> new Configuration(mavenSessionMock))
                 .withMessageContaining(Property.buildUpstreamMode.prefixedName())
                 .withCauseExactlyInstanceOf(IllegalArgumentException.class);
     }
@@ -266,7 +266,7 @@ public class ConfigurationTest {
         System.setProperty(Property.buildUpstream.prefixedName(), "derived");
         when(mavenExecutionRequestMock.getMakeBehavior()).thenReturn(MavenExecutionRequest.REACTOR_MAKE_UPSTREAM);
 
-        Configuration configuration = new Configuration.Provider(mavenSessionMock).get();
+        Configuration configuration = new Configuration(mavenSessionMock);
 
         assertSame(BuildUpstreamMode.CHANGED, configuration.buildUpstreamMode);
     }
@@ -277,7 +277,7 @@ public class ConfigurationTest {
     // 'always' is default
     @Test
     public void buildDownstream() {
-        Configuration configuration = new Configuration.Provider(mavenSessionMock).get();
+        Configuration configuration = new Configuration(mavenSessionMock);
 
         assertTrue(configuration.buildDownstream);
         verify(mavenExecutionRequestMock, times(1)).getMakeBehavior();  // called once for buildDownstreamMode
@@ -287,7 +287,7 @@ public class ConfigurationTest {
     public void buildDownstream_never() {
         System.setProperty(Property.buildDownstream.prefixedName(), "never");
 
-        Configuration configuration = new Configuration.Provider(mavenSessionMock).get();
+        Configuration configuration = new Configuration(mavenSessionMock);
 
         assertFalse(configuration.buildDownstream);
         verify(mavenExecutionRequestMock, times(1)).getMakeBehavior();  // called once for buildDownstreamMode
@@ -297,7 +297,7 @@ public class ConfigurationTest {
     public void buildDownstream_false() {
         System.setProperty(Property.buildDownstream.prefixedName(), "false");
 
-        Configuration configuration = new Configuration.Provider(mavenSessionMock).get();
+        Configuration configuration = new Configuration(mavenSessionMock);
 
         assertFalse(configuration.buildDownstream);
         verify(mavenExecutionRequestMock, times(1)).getMakeBehavior();  // called once for buildDownstreamMode
@@ -307,7 +307,7 @@ public class ConfigurationTest {
     public void buildDownstream_always() {
         System.setProperty(Property.buildDownstream.prefixedName(), "always");
 
-        Configuration configuration = new Configuration.Provider(mavenSessionMock).get();
+        Configuration configuration = new Configuration(mavenSessionMock);
 
         assertTrue(configuration.buildDownstream);
         verify(mavenExecutionRequestMock, times(1)).getMakeBehavior();  // called once for buildDownstreamMode
@@ -317,7 +317,7 @@ public class ConfigurationTest {
     public void buildDownstream_true() {
         System.setProperty(Property.buildDownstream.prefixedName(), "true");
 
-        Configuration configuration = new Configuration.Provider(mavenSessionMock).get();
+        Configuration configuration = new Configuration(mavenSessionMock);
 
         assertTrue(configuration.buildDownstream);
         verify(mavenExecutionRequestMock, times(1)).getMakeBehavior();  // called once for buildDownstreamMode
@@ -327,7 +327,7 @@ public class ConfigurationTest {
     public void buildDownstream_unknown() {
         System.setProperty(Property.buildDownstream.prefixedName(), "foo");
 
-        assertThatIllegalArgumentException().isThrownBy(() -> new Configuration.Provider(mavenSessionMock).get())
+        assertThatIllegalArgumentException().isThrownBy(() -> new Configuration(mavenSessionMock))
                 .withMessageContaining(Property.buildDownstream.prefixedName());
     }
 
@@ -335,7 +335,7 @@ public class ConfigurationTest {
     public void buildDownstream_derived_noMake() {
         System.setProperty(Property.buildDownstream.prefixedName(), "derived");
 
-        Configuration configuration = new Configuration.Provider(mavenSessionMock).get();
+        Configuration configuration = new Configuration(mavenSessionMock);
 
         assertFalse(configuration.buildDownstream);
     }
@@ -345,7 +345,7 @@ public class ConfigurationTest {
         System.setProperty(Property.buildDownstream.prefixedName(), "derived");
         when(mavenExecutionRequestMock.getMakeBehavior()).thenReturn(MavenExecutionRequest.REACTOR_MAKE_DOWNSTREAM);
 
-        Configuration configuration = new Configuration.Provider(mavenSessionMock).get();
+        Configuration configuration = new Configuration(mavenSessionMock);
 
         assertTrue(configuration.buildDownstream);
     }
@@ -355,7 +355,7 @@ public class ConfigurationTest {
         System.setProperty(Property.buildDownstream.prefixedName(), "derived");
         when(mavenExecutionRequestMock.getMakeBehavior()).thenReturn(MavenExecutionRequest.REACTOR_MAKE_BOTH);
 
-        Configuration configuration = new Configuration.Provider(mavenSessionMock).get();
+        Configuration configuration = new Configuration(mavenSessionMock);
 
         assertTrue(configuration.buildDownstream);
     }
@@ -365,7 +365,7 @@ public class ConfigurationTest {
         System.setProperty(Property.buildDownstream.prefixedName(), "derived");
         when(mavenExecutionRequestMock.getMakeBehavior()).thenReturn(MavenExecutionRequest.REACTOR_MAKE_UPSTREAM);
 
-        Configuration configuration = new Configuration.Provider(mavenSessionMock).get();
+        Configuration configuration = new Configuration(mavenSessionMock);
 
         assertFalse(configuration.buildDownstream);
     }
@@ -374,7 +374,7 @@ public class ConfigurationTest {
     public void plugin_baseBranch() {
         mockPluginConfig(Property.baseBranch.name(), "foo");
 
-        Configuration configuration = new Configuration.Provider(mavenSessionMock).get();
+        Configuration configuration = new Configuration(mavenSessionMock);
 
         assertEquals("foo", configuration.baseBranch);
     }
@@ -384,7 +384,7 @@ public class ConfigurationTest {
         mockPluginConfig(Property.baseBranch.name(), "foo");
         projectProperties.put(Property.baseBranch.prefixedName(), "bar");
 
-        Configuration configuration = new Configuration.Provider(mavenSessionMock).get();
+        Configuration configuration = new Configuration(mavenSessionMock);
 
         assertEquals("foo", configuration.baseBranch);
     }
@@ -394,7 +394,7 @@ public class ConfigurationTest {
         mockPlugin(null);
         projectProperties.put(Property.baseBranch.prefixedName(), "foo");
 
-        Configuration configuration = new Configuration.Provider(mavenSessionMock).get();
+        Configuration configuration = new Configuration(mavenSessionMock);
 
         assertEquals("foo", configuration.baseBranch);
     }
@@ -404,7 +404,7 @@ public class ConfigurationTest {
         mockPlugin(mock(Xpp3Dom.class));
         projectProperties.put(Property.baseBranch.prefixedName(), "foo");
 
-        Configuration configuration = new Configuration.Provider(mavenSessionMock).get();
+        Configuration configuration = new Configuration(mavenSessionMock);
 
         assertEquals("foo", configuration.baseBranch);
     }
@@ -416,7 +416,7 @@ public class ConfigurationTest {
         mockPlugin(configMock);
         projectProperties.put(Property.baseBranch.prefixedName(), "foo");
 
-        Configuration configuration = new Configuration.Provider(mavenSessionMock).get();
+        Configuration configuration = new Configuration(mavenSessionMock);
 
         assertEquals("foo", configuration.baseBranch);
     }

--- a/src/test/java/com/vackosar/gitflowincrementalbuild/boundary/ConfigurationTest.java
+++ b/src/test/java/com/vackosar/gitflowincrementalbuild/boundary/ConfigurationTest.java
@@ -421,6 +421,25 @@ public class ConfigurationTest {
         assertEquals("foo", configuration.baseBranch);
     }
 
+    @Test
+    public void noTopLevelProject_noCurrentProject() {
+        when(mavenSessionMock.getTopLevelProject()).thenReturn(null);
+
+        Configuration configuration = new Configuration(mavenSessionMock);
+
+        assertFalse(configuration.enabled);
+    }
+
+    @Test
+    public void noTopLevelProject_fallbackToCurrentProject() {
+        when(mavenSessionMock.getTopLevelProject()).thenReturn(null);
+        when(mavenSessionMock.getCurrentProject()).thenReturn(mockTLProject);
+
+        Configuration configuration = new Configuration(mavenSessionMock);
+
+        assertTrue(configuration.enabled);
+    }
+
     private void mockPluginConfig(String propertyName, String value) {
         Xpp3Dom childConfigMock = mock(Xpp3Dom.class);
         when(childConfigMock.getName()).thenReturn(propertyName);

--- a/src/test/java/com/vackosar/gitflowincrementalbuild/boundary/MavenLifecycleParticipantTest.java
+++ b/src/test/java/com/vackosar/gitflowincrementalbuild/boundary/MavenLifecycleParticipantTest.java
@@ -18,13 +18,13 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.powermock.reflect.Whitebox;
 import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
@@ -65,8 +65,6 @@ public class MavenLifecycleParticipantTest {
         when(mavenSessionMock.getRequest()).thenReturn(mock(MavenExecutionRequest.class));
 
         when(mavenSessionMock.getProjectDependencyGraph()).thenReturn(mock(ProjectDependencyGraph.class));
-
-        Whitebox.setInternalState(underTest, new Configuration.Provider(mavenSessionMock));
     }
 
     @Test
@@ -75,7 +73,7 @@ public class MavenLifecycleParticipantTest {
         underTest.afterProjectsRead(mavenSessionMock);
 
         verify(loggerSpy).info(contains("starting..."), eq(TEST_IMPL_VERSION));
-        verify(unchangedProjectsRemoverMock).act();
+        verify(unchangedProjectsRemoverMock).act(any(Configuration.class));
     }
 
     @Test
@@ -107,7 +105,7 @@ public class MavenLifecycleParticipantTest {
         underTest.afterProjectsRead(mavenSessionMock);
 
         verifyHelpLogged(true);
-        verify(unchangedProjectsRemoverMock).act();
+        verify(unchangedProjectsRemoverMock).act(any(Configuration.class));
     }
 
     @Test
@@ -121,7 +119,7 @@ public class MavenLifecycleParticipantTest {
     @Test
     public void onRuntimeException() throws Exception {
         RuntimeException runtimeException = new RuntimeException("FAIL !!!");
-        doThrow(runtimeException).when(unchangedProjectsRemoverMock).act();
+        doThrow(runtimeException).when(unchangedProjectsRemoverMock).act(any(Configuration.class));
 
         assertThatExceptionOfType(MavenExecutionException.class).isThrownBy(() -> underTest.afterProjectsRead(mavenSessionMock))
                 .withCause(runtimeException);
@@ -131,7 +129,7 @@ public class MavenLifecycleParticipantTest {
     public void onRuntimeException_failOnErrorFalse() throws Exception {
         projectProperties.setProperty(Property.failOnError.prefixedName(), "false");
         RuntimeException runtimeException = new RuntimeException("FAIL !!!");
-        doThrow(runtimeException).when(unchangedProjectsRemoverMock).act();
+        doThrow(runtimeException).when(unchangedProjectsRemoverMock).act(any(Configuration.class));
 
         underTest.afterProjectsRead(mavenSessionMock);
 
@@ -142,7 +140,7 @@ public class MavenLifecycleParticipantTest {
     @Test
     public void onSkipExecutionException() throws Exception {
         SkipExecutionException skipExecutionException = new SkipExecutionException("FAIL !!!");
-        doThrow(skipExecutionException).when(unchangedProjectsRemoverMock).act();
+        doThrow(skipExecutionException).when(unchangedProjectsRemoverMock).act(any(Configuration.class));
 
         underTest.afterProjectsRead(mavenSessionMock);
 
@@ -168,7 +166,7 @@ public class MavenLifecycleParticipantTest {
 
         underTest.afterProjectsRead(mavenSessionMock);
 
-        verify(unchangedProjectsRemoverMock).act();
+        verify(unchangedProjectsRemoverMock).act(any(Configuration.class));
     }
 
     @Test
@@ -188,7 +186,7 @@ public class MavenLifecycleParticipantTest {
         Repository repository = mock(Repository.class);
         when(git.getRepository()).thenReturn(repository);
         when(repository.getBranch()).thenReturn(branchName);
-        when(gitProviderMock.get()).thenReturn(git);
+        when(gitProviderMock.get(any(Configuration.class))).thenReturn(git);
     }
 
     private void verifyHelpLogged(boolean logged) {

--- a/src/test/java/com/vackosar/gitflowincrementalbuild/boundary/UnchangedProjectsRemoverLogImpactedTest.java
+++ b/src/test/java/com/vackosar/gitflowincrementalbuild/boundary/UnchangedProjectsRemoverLogImpactedTest.java
@@ -38,7 +38,7 @@ public class UnchangedProjectsRemoverLogImpactedTest extends BaseUnchangedProjec
     public void logImpatcedTo_nothingChanged() throws GitAPIException, IOException {
         addModuleMock(AID_MODULE_B, false);
 
-        underTest.act();
+        underTest.act(config());
 
         assertLogFileContains();
     }
@@ -47,7 +47,7 @@ public class UnchangedProjectsRemoverLogImpactedTest extends BaseUnchangedProjec
     public void singleChanged() throws GitAPIException, IOException {
         MavenProject changedModuleMock = addModuleMock(AID_MODULE_B, true);
 
-        underTest.act();
+        underTest.act(config());
 
         assertLogFileContains(changedModuleMock);
     }
@@ -62,7 +62,7 @@ public class UnchangedProjectsRemoverLogImpactedTest extends BaseUnchangedProjec
         setDownstreamProjects(changedModuleMock, dependentModuleMock);
         setUpstreamProjects(independentModuleMock, moduleA);
 
-        underTest.act();
+        underTest.act(config());
 
         assertLogFileContains(changedModuleMock, dependentModuleMock);
     }
@@ -73,7 +73,7 @@ public class UnchangedProjectsRemoverLogImpactedTest extends BaseUnchangedProjec
 
         addGibProperty(Property.buildUpstream, "true");
 
-        underTest.act();
+        underTest.act(config());
 
         assertLogFileContains(changedModuleMock);
     }

--- a/src/test/java/com/vackosar/gitflowincrementalbuild/boundary/UnchangedProjectsRemoverSelectedProjectsTest.java
+++ b/src/test/java/com/vackosar/gitflowincrementalbuild/boundary/UnchangedProjectsRemoverSelectedProjectsTest.java
@@ -40,7 +40,7 @@ public class UnchangedProjectsRemoverSelectedProjectsTest extends BaseUnchangedP
         setProjectSelections(moduleB);
         overrideProjects(moduleB);
 
-        underTest.act();
+        underTest.act(config());
 
         assertEquals(Collections.emptyList(), mavenSessionMock.getGoals(), "Unexpected goals");
 
@@ -57,7 +57,7 @@ public class UnchangedProjectsRemoverSelectedProjectsTest extends BaseUnchangedP
         setProjectSelections(moduleB, moduleC);
         overrideProjects(moduleB, moduleC);
 
-        underTest.act();
+        underTest.act(config());
 
         assertEquals(Collections.emptyList(), mavenSessionMock.getGoals(), "Unexpected goals");
 
@@ -74,7 +74,7 @@ public class UnchangedProjectsRemoverSelectedProjectsTest extends BaseUnchangedP
         setProjectSelections(moduleB);
         when(mavenExecutionRequestMock.getMakeBehavior()).thenReturn(MavenExecutionRequest.REACTOR_MAKE_UPSTREAM);
 
-        underTest.act();
+        underTest.act(config());
 
         assertEquals(Collections.emptyList(), mavenSessionMock.getGoals(), "Unexpected goals");
 
@@ -97,7 +97,7 @@ public class UnchangedProjectsRemoverSelectedProjectsTest extends BaseUnchangedP
 
         when(mavenExecutionRequestMock.getMakeBehavior()).thenReturn(MavenExecutionRequest.REACTOR_MAKE_DOWNSTREAM);
 
-        underTest.act();
+        underTest.act(config());
 
         assertEquals(Collections.emptyList(), mavenSessionMock.getGoals(), "Unexpected goals");
 
@@ -123,7 +123,7 @@ public class UnchangedProjectsRemoverSelectedProjectsTest extends BaseUnchangedP
 
         addGibProperty(Property.buildDownstream, "false");
 
-        underTest.act();
+        underTest.act(config());
 
         assertEquals(Collections.emptyList(), mavenSessionMock.getGoals(), "Unexpected goals");
 
@@ -154,7 +154,7 @@ public class UnchangedProjectsRemoverSelectedProjectsTest extends BaseUnchangedP
 
         when(mavenExecutionRequestMock.getMakeBehavior()).thenReturn(MavenExecutionRequest.REACTOR_MAKE_DOWNSTREAM);
 
-        underTest.act();
+        underTest.act(config());
 
         assertEquals(Collections.emptyList(), mavenSessionMock.getGoals(), "Unexpected goals");
 
@@ -179,7 +179,7 @@ public class UnchangedProjectsRemoverSelectedProjectsTest extends BaseUnchangedP
 
         when(mavenExecutionRequestMock.getMakeBehavior()).thenReturn(MavenExecutionRequest.REACTOR_MAKE_BOTH);
 
-        underTest.act();
+        underTest.act(config());
 
         assertEquals(Collections.emptyList(), mavenSessionMock.getGoals(), "Unexpected goals");
 
@@ -198,7 +198,7 @@ public class UnchangedProjectsRemoverSelectedProjectsTest extends BaseUnchangedP
 
         changedProjects.add(moduleA);
 
-        underTest.act();
+        underTest.act(config());
 
         verify(mavenSessionMock, never()).setProjects(anyList());
     }
@@ -212,7 +212,7 @@ public class UnchangedProjectsRemoverSelectedProjectsTest extends BaseUnchangedP
 
         changedProjects.add(moduleA);
 
-        underTest.act();
+        underTest.act(config());
 
         verify(mavenSessionMock).setProjects(Arrays.asList(moduleA, moduleB));
 
@@ -231,7 +231,7 @@ public class UnchangedProjectsRemoverSelectedProjectsTest extends BaseUnchangedP
 
         addGibProperty(Property.buildUpstream, "false");
 
-        underTest.act();
+        underTest.act(config());
 
         verify(mavenSessionMock).setProjects(Collections.singletonList(moduleB));
 
@@ -252,7 +252,7 @@ public class UnchangedProjectsRemoverSelectedProjectsTest extends BaseUnchangedP
 
         changedProjects.add(moduleA);
 
-        underTest.act();
+        underTest.act(config());
 
         // upstream B was not changed but its upstream A, so B must be built as well
         verify(mavenSessionMock).setProjects(Arrays.asList(moduleA, moduleB, moduleC));
@@ -277,7 +277,7 @@ public class UnchangedProjectsRemoverSelectedProjectsTest extends BaseUnchangedP
 
         changedProjects.add(moduleA);
 
-        underTest.act();
+        underTest.act(config());
 
         verify(mavenSessionMock).setProjects(Arrays.asList(moduleA, moduleB, moduleC));
 
@@ -303,7 +303,7 @@ public class UnchangedProjectsRemoverSelectedProjectsTest extends BaseUnchangedP
 
         changedProjects.add(moduleA);
 
-        underTest.act();
+        underTest.act(config());
 
         verify(mavenSessionMock).setProjects(Arrays.asList(moduleB, moduleC));
 
@@ -328,7 +328,7 @@ public class UnchangedProjectsRemoverSelectedProjectsTest extends BaseUnchangedP
 
         changedProjects.add(moduleA);
 
-        underTest.act();
+        underTest.act(config());
 
         verify(mavenSessionMock).setProjects(Arrays.asList(moduleA, moduleB));
 
@@ -354,7 +354,7 @@ public class UnchangedProjectsRemoverSelectedProjectsTest extends BaseUnchangedP
 
         changedProjects.add(moduleA);
 
-        underTest.act();
+        underTest.act(config());
 
         verify(mavenSessionMock).setProjects(Collections.singletonList(moduleB));
 
@@ -375,7 +375,7 @@ public class UnchangedProjectsRemoverSelectedProjectsTest extends BaseUnchangedP
 
         changedProjects.add(moduleA);
 
-        underTest.act();
+        underTest.act(config());
 
         verify(mavenSessionMock).setProjects(Arrays.asList(moduleB, moduleC));
     }
@@ -396,7 +396,7 @@ public class UnchangedProjectsRemoverSelectedProjectsTest extends BaseUnchangedP
 
         changedProjects.add(moduleA);
 
-        underTest.act();
+        underTest.act(config());
 
         verify(mavenSessionMock).setProjects(Collections.singletonList(moduleB));
     }
@@ -418,7 +418,7 @@ public class UnchangedProjectsRemoverSelectedProjectsTest extends BaseUnchangedP
 
         changedProjects.add(moduleA);
 
-        underTest.act();
+        underTest.act(config());
 
         verify(mavenSessionMock, never()).setProjects(anyList());
 
@@ -433,7 +433,7 @@ public class UnchangedProjectsRemoverSelectedProjectsTest extends BaseUnchangedP
         setProjectSelections(moduleB);
         overrideProjects(moduleB);
 
-        underTest.act();
+        underTest.act(config());
 
         verify(mavenSessionMock, never()).setProjects(anyList());
     }
@@ -445,7 +445,7 @@ public class UnchangedProjectsRemoverSelectedProjectsTest extends BaseUnchangedP
         setProjectSelections(moduleB);
         when(mavenExecutionRequestMock.getMakeBehavior()).thenReturn(MavenExecutionRequest.REACTOR_MAKE_UPSTREAM);
 
-        underTest.act();
+        underTest.act(config());
 
         verify(mavenSessionMock).setProjects(Collections.singletonList(moduleB));
 
@@ -461,7 +461,7 @@ public class UnchangedProjectsRemoverSelectedProjectsTest extends BaseUnchangedP
 
         addGibProperty(Property.buildAll, "true");
 
-        underTest.act();
+        underTest.act(config());
 
         verify(mavenSessionMock, never()).setProjects(anyList());
 
@@ -478,7 +478,7 @@ public class UnchangedProjectsRemoverSelectedProjectsTest extends BaseUnchangedP
 
         addGibProperty(Property.forceBuildModules, "module-A");
 
-        underTest.act();
+        underTest.act(config());
 
         verify(mavenSessionMock).setProjects(Arrays.asList(moduleA, moduleB));
 
@@ -499,7 +499,7 @@ public class UnchangedProjectsRemoverSelectedProjectsTest extends BaseUnchangedP
 
         when(mavenExecutionRequestMock.getMakeBehavior()).thenReturn(MavenExecutionRequest.REACTOR_MAKE_BOTH);
 
-        underTest.act();
+        underTest.act(config());
 
         verify(mavenSessionMock).setProjects(Arrays.asList(moduleB, moduleC));
 
@@ -519,7 +519,7 @@ public class UnchangedProjectsRemoverSelectedProjectsTest extends BaseUnchangedP
         setProjectDeSelections(moduleB);
         overrideProjects(moduleA, moduleC);
 
-        underTest.act();
+        underTest.act(config());
 
         verify(mavenSessionMock).setProjects(Collections.singletonList(moduleC));
     }
@@ -538,7 +538,7 @@ public class UnchangedProjectsRemoverSelectedProjectsTest extends BaseUnchangedP
 
         addGibProperty(Property.buildDownstream, "false");
 
-        underTest.act();
+        underTest.act(config());
 
         verify(mavenSessionMock).setProjects(Collections.singletonList(moduleA));
 
@@ -560,7 +560,7 @@ public class UnchangedProjectsRemoverSelectedProjectsTest extends BaseUnchangedP
         addGibProperty(Property.buildDownstream, "false");
         addGibProperty(Property.buildAllIfNoChanges, "true");
 
-        underTest.act();
+        underTest.act(config());
 
         verify(mavenSessionMock, never()).setProjects(anyList());
 
@@ -582,7 +582,7 @@ public class UnchangedProjectsRemoverSelectedProjectsTest extends BaseUnchangedP
 
         addGibProperty(Property.buildUpstream, "true");
 
-        underTest.act();
+        underTest.act(config());
 
         verify(mavenSessionMock).setProjects(Arrays.asList(moduleA, moduleC));
 
@@ -605,7 +605,7 @@ public class UnchangedProjectsRemoverSelectedProjectsTest extends BaseUnchangedP
         addGibProperty(Property.buildUpstream, "true");
         addGibProperty(Property.buildDownstream, "false");
 
-        underTest.act();
+        underTest.act(config());
 
         verify(mavenSessionMock).setProjects(Collections.singletonList(moduleA));
 
@@ -633,7 +633,7 @@ public class UnchangedProjectsRemoverSelectedProjectsTest extends BaseUnchangedP
 
         when(mavenExecutionRequestMock.getMakeBehavior()).thenReturn(MavenExecutionRequest.REACTOR_MAKE_UPSTREAM);
 
-        underTest.act();
+        underTest.act(config());
 
         verify(mavenSessionMock).setProjects(Arrays.asList(moduleB, moduleC, moduleD, moduleE));
 
@@ -665,7 +665,7 @@ public class UnchangedProjectsRemoverSelectedProjectsTest extends BaseUnchangedP
 
         when(mavenExecutionRequestMock.getMakeBehavior()).thenReturn(MavenExecutionRequest.REACTOR_MAKE_UPSTREAM);
 
-        underTest.act();
+        underTest.act(config());
 
         verify(mavenSessionMock).setProjects(Arrays.asList(moduleC, moduleD, moduleE));
 

--- a/src/test/java/com/vackosar/gitflowincrementalbuild/boundary/UnchangedProjectsRemoverTest.java
+++ b/src/test/java/com/vackosar/gitflowincrementalbuild/boundary/UnchangedProjectsRemoverTest.java
@@ -34,7 +34,7 @@ public class UnchangedProjectsRemoverTest extends BaseUnchangedProjectsRemoverTe
     public void nothingChanged() throws GitAPIException, IOException {
         MavenProject moduleB = addModuleMock(AID_MODULE_B, false);
 
-        underTest.act();
+        underTest.act(config());
 
         assertEquals(Collections.singletonList("validate"), mavenSessionMock.getGoals(), "Unexpected goal");
 
@@ -51,7 +51,7 @@ public class UnchangedProjectsRemoverTest extends BaseUnchangedProjectsRemoverTe
         addGibProperty(Property.buildAllIfNoChanges, "true");
         addGibProperty(Property.skipTestsForUpstreamModules, "true");
 
-        underTest.act();
+        underTest.act(config());
 
         assertEquals(Collections.emptyList(), mavenSessionMock.getGoals(), "Unexpected goals");
 
@@ -67,7 +67,7 @@ public class UnchangedProjectsRemoverTest extends BaseUnchangedProjectsRemoverTe
         // note: a more realistic setup would require a proper parent/root
         moduleA.getModel().addModule("test");
 
-        underTest.act();
+        underTest.act(config());
 
         assertEquals(Collections.singletonList("validate"), mavenSessionMock.getGoals(), "Unexpected goal");
 
@@ -84,7 +84,7 @@ public class UnchangedProjectsRemoverTest extends BaseUnchangedProjectsRemoverTe
         moduleA.getModel().addModule("test");
         when(mavenExecutionRequestMock.isRecursive()).thenReturn(false);
 
-        underTest.act();
+        underTest.act(config());
 
         assertEquals(Collections.emptyList(), mavenSessionMock.getGoals(), "Unexpected goals");
 
@@ -102,7 +102,7 @@ public class UnchangedProjectsRemoverTest extends BaseUnchangedProjectsRemoverTe
         // emulate -f module-B
         overrideProjects(moduleB);
 
-        underTest.act();
+        underTest.act(config());
 
         assertEquals(Collections.emptyList(), mavenSessionMock.getGoals(), "Unexpected goals");
 
@@ -117,7 +117,7 @@ public class UnchangedProjectsRemoverTest extends BaseUnchangedProjectsRemoverTe
     public void singleChanged() throws GitAPIException, IOException {
         MavenProject changedModuleMock = addModuleMock(AID_MODULE_B, true);
 
-        underTest.act();
+        underTest.act(config());
 
         verify(mavenSessionMock).setProjects(Collections.singletonList(changedModuleMock));
     }
@@ -128,7 +128,7 @@ public class UnchangedProjectsRemoverTest extends BaseUnchangedProjectsRemoverTe
 
         when(mavenExecutionRequestMock.getMakeBehavior()).thenReturn(MavenExecutionRequest.REACTOR_MAKE_UPSTREAM);
 
-        underTest.act();
+        underTest.act(config());
 
         verify(mavenSessionMock).setProjects(Arrays.asList(moduleA, changedModuleMock));
 
@@ -144,7 +144,7 @@ public class UnchangedProjectsRemoverTest extends BaseUnchangedProjectsRemoverTe
 
         addGibProperty(Property.skipTestsForUpstreamModules, "true");
 
-        underTest.act();
+        underTest.act(config());
 
         verify(mavenSessionMock).setProjects(Arrays.asList(moduleA, changedModuleMock));
 
@@ -166,7 +166,7 @@ public class UnchangedProjectsRemoverTest extends BaseUnchangedProjectsRemoverTe
         when(pluginMock.getExecutions()).thenReturn(Collections.singletonList(execMock));
         when(moduleA.getBuildPlugins()).thenReturn(Collections.singletonList(pluginMock));
 
-        underTest.act();
+        underTest.act(config());
 
         verify(mavenSessionMock).setProjects(Arrays.asList(moduleA, changedModuleMock));
 
@@ -182,7 +182,7 @@ public class UnchangedProjectsRemoverTest extends BaseUnchangedProjectsRemoverTe
 
         addGibProperty(Property.argsForUpstreamModules, "enforcer.skip=true argWithNoValue");
 
-        underTest.act();
+        underTest.act(config());
 
         verify(mavenSessionMock).setProjects(Arrays.asList(moduleA, changedModuleMock));
 
@@ -202,7 +202,7 @@ public class UnchangedProjectsRemoverTest extends BaseUnchangedProjectsRemoverTe
 
         addGibProperty(Property.buildUpstreamMode, "changed");
 
-        underTest.act();
+        underTest.act(config());
 
         verify(mavenSessionMock).setProjects(Arrays.asList(moduleA, changedModuleMock, dependsOnBothModuleMock));
 
@@ -225,7 +225,7 @@ public class UnchangedProjectsRemoverTest extends BaseUnchangedProjectsRemoverTe
         addGibProperty(Property.buildUpstreamMode, "changed");
         addGibProperty(Property.argsForUpstreamModules, "foo=bar");
 
-        underTest.act();
+        underTest.act(config());
 
         verify(mavenSessionMock).setProjects(Arrays.asList(moduleA, changedModuleMock, dependsOnBothModuleMock));
 
@@ -251,7 +251,7 @@ public class UnchangedProjectsRemoverTest extends BaseUnchangedProjectsRemoverTe
         addGibProperty(Property.buildUpstreamMode, "changed");
         addGibProperty(Property.argsForUpstreamModules, "foo=bar");
 
-        underTest.act();
+        underTest.act(config());
 
         verify(mavenSessionMock).setProjects(
                 Arrays.asList(moduleA, changedModuleMock, unchangedIntermediateModuleMock, dependsOnIntermediateModuleMock));
@@ -274,7 +274,7 @@ public class UnchangedProjectsRemoverTest extends BaseUnchangedProjectsRemoverTe
 
         addGibProperty(Property.buildUpstreamMode, "impacted");
 
-        underTest.act();
+        underTest.act(config());
 
         verify(mavenSessionMock).setProjects(Arrays.asList(moduleA, changedModuleMock, unchangedModuleMock, dependsOnBothModuleMock));
 
@@ -297,7 +297,7 @@ public class UnchangedProjectsRemoverTest extends BaseUnchangedProjectsRemoverTe
         addGibProperty(Property.buildUpstreamMode, "impacted");
         addGibProperty(Property.argsForUpstreamModules, "foo=bar");
 
-        underTest.act();
+        underTest.act(config());
 
         verify(mavenSessionMock).setProjects(Arrays.asList(moduleA, changedModuleMock, unchangedModuleMock, dependsOnBothModuleMock));
 
@@ -323,7 +323,7 @@ public class UnchangedProjectsRemoverTest extends BaseUnchangedProjectsRemoverTe
         addGibProperty(Property.buildUpstreamMode, "impacted");
         addGibProperty(Property.argsForUpstreamModules, "foo=bar");
 
-        underTest.act();
+        underTest.act(config());
 
         verify(mavenSessionMock).setProjects(
                 Arrays.asList(moduleA, changedModuleMock, unchangedIntermediateModuleMock, dependsOnIntermediateModuleMock));
@@ -341,7 +341,7 @@ public class UnchangedProjectsRemoverTest extends BaseUnchangedProjectsRemoverTe
         addGibProperty(Property.argsForUpstreamModules, "enforcer.skip=true argWithNoValue");
         addGibProperty(Property.buildAll, "true");
 
-        underTest.act();
+        underTest.act(config());
 
         verify(mavenSessionMock, never()).setProjects(anyList());
 
@@ -359,7 +359,7 @@ public class UnchangedProjectsRemoverTest extends BaseUnchangedProjectsRemoverTe
 
         // buildDownstream is enabled by default!
 
-        underTest.act();
+        underTest.act(config());
 
         verify(mavenSessionMock).setProjects(Arrays.asList(changedModuleMock, dependentModuleMock));
     }
@@ -374,7 +374,7 @@ public class UnchangedProjectsRemoverTest extends BaseUnchangedProjectsRemoverTe
 
         addGibProperty(Property.buildDownstream, "false");
 
-        underTest.act();
+        underTest.act(config());
 
         verify(mavenSessionMock).setProjects(Arrays.asList(changedModuleMock));
     }
@@ -391,7 +391,7 @@ public class UnchangedProjectsRemoverTest extends BaseUnchangedProjectsRemoverTe
         addGibProperty(Property.buildAll, "true");
         addGibProperty(Property.argsForUpstreamModules, "foo=bar");
 
-        underTest.act();
+        underTest.act(config());
 
         verify(mavenSessionMock, never()).setProjects(anyList());
 
@@ -406,7 +406,7 @@ public class UnchangedProjectsRemoverTest extends BaseUnchangedProjectsRemoverTe
 
         addGibProperty(Property.forceBuildModules, moduleA.getArtifactId());
 
-        underTest.act();
+        underTest.act(config());
 
         verify(mavenSessionMock).setProjects(Arrays.asList(moduleA, changedModuleMock));
     }
@@ -418,7 +418,7 @@ public class UnchangedProjectsRemoverTest extends BaseUnchangedProjectsRemoverTe
 
         addGibProperty(Property.forceBuildModules, moduleA.getArtifactId() + "," + unchangedModuleMock.getArtifactId());
 
-        underTest.act();
+        underTest.act(config());
 
         verify(mavenSessionMock).setProjects(
                 Arrays.asList(moduleA, changedModuleMock, unchangedModuleMock));
@@ -431,7 +431,7 @@ public class UnchangedProjectsRemoverTest extends BaseUnchangedProjectsRemoverTe
 
         addGibProperty(Property.forceBuildModules, AID_MODULE_A + ".*");
 
-        underTest.act();
+        underTest.act(config());
 
         verify(mavenSessionMock).setProjects(
                 Arrays.asList(moduleA, changedModuleMock, unchangedModuleMock));
@@ -444,7 +444,7 @@ public class UnchangedProjectsRemoverTest extends BaseUnchangedProjectsRemoverTe
 
         addGibProperty(Property.forceBuildModules, AID_MODULE_A +  ".*,.*-C");
 
-        underTest.act();
+        underTest.act(config());
 
         verify(mavenSessionMock).setProjects(
                 Arrays.asList(moduleA, changedModuleMock, unchangedModuleMock));
@@ -459,7 +459,7 @@ public class UnchangedProjectsRemoverTest extends BaseUnchangedProjectsRemoverTe
 
         addGibProperty(Property.excludeDownstreamModulesPackagedAs, "war");
 
-        underTest.act();
+        underTest.act(config());
 
         verify(mavenSessionMock).setProjects(
                 Arrays.asList(changedProjectMock));
@@ -475,7 +475,7 @@ public class UnchangedProjectsRemoverTest extends BaseUnchangedProjectsRemoverTe
 
         addGibProperty(Property.excludeDownstreamModulesPackagedAs, "war");
 
-        underTest.act();
+        underTest.act(config());
 
         verify(mavenSessionMock).setProjects(
                 Arrays.asList(changedProjectMock, dependentJar));
@@ -491,7 +491,7 @@ public class UnchangedProjectsRemoverTest extends BaseUnchangedProjectsRemoverTe
 
         addGibProperty(Property.excludeDownstreamModulesPackagedAs, "war,ear");
 
-        underTest.act();
+        underTest.act(config());
 
         verify(mavenSessionMock).setProjects(
                 Arrays.asList(changedProjectMock));
@@ -507,7 +507,7 @@ public class UnchangedProjectsRemoverTest extends BaseUnchangedProjectsRemoverTe
         addGibProperty(Property.excludeDownstreamModulesPackagedAs, "war");
         addGibProperty(Property.buildAll, "true");
 
-        underTest.act();
+        underTest.act(config());
 
         verify(mavenSessionMock, never())
                 .setProjects(anyList());
@@ -523,7 +523,7 @@ public class UnchangedProjectsRemoverTest extends BaseUnchangedProjectsRemoverTe
         addGibProperty(Property.excludeDownstreamModulesPackagedAs, "war");
         addGibProperty(Property.forceBuildModules, dependentWar.getArtifactId());
 
-        underTest.act();
+        underTest.act(config());
 
         verify(mavenSessionMock).setProjects(
                 Arrays.asList(changedProjectMock, dependentWar));
@@ -538,7 +538,7 @@ public class UnchangedProjectsRemoverTest extends BaseUnchangedProjectsRemoverTe
 
         addGibProperty(Property.excludeDownstreamModulesPackagedAs, "war");
 
-        underTest.act();
+        underTest.act(config());
 
         verify(mavenSessionMock).setProjects(
                 Arrays.asList(changedProjectMock, dependentWar));
@@ -554,7 +554,7 @@ public class UnchangedProjectsRemoverTest extends BaseUnchangedProjectsRemoverTe
 
         addGibProperty(Property.excludeDownstreamModulesPackagedAs, "war");
 
-        underTest.act();
+        underTest.act(config());
 
         verify(mavenSessionMock).setProjects(
                 Arrays.asList(changedProjectMock, dependentWar));

--- a/src/test/java/com/vackosar/gitflowincrementalbuild/control/BaseChangedProjectsTest.java
+++ b/src/test/java/com/vackosar/gitflowincrementalbuild/control/BaseChangedProjectsTest.java
@@ -56,10 +56,8 @@ public abstract class BaseChangedProjectsTest extends BaseRepoTest {
     @BeforeEach
     void injectMavenSessionMockAndGitProvider() throws Exception {
         mavenSessionMock = getMavenSessionMock();
-        Configuration.Provider configProvider = new Configuration.Provider(mavenSessionMock);
-        gitProvider = new GitProvider(mavenSessionMock, configProvider.get());
-        Whitebox.setInternalState(differentFilesSpy, configProvider, gitProvider);
-        Whitebox.setInternalState(underTest, mavenSessionMock);
+        gitProvider = new GitProvider();
+        Whitebox.setInternalState(differentFilesSpy, gitProvider);
     }
 
     @AfterEach
@@ -78,7 +76,7 @@ public abstract class BaseChangedProjectsTest extends BaseRepoTest {
                 Paths.get("parent/testJarDependent")
         ));
 
-        final Set<Path> actual = underTest.get().stream()
+        final Set<Path> actual = underTest.get(config()).stream()
                 .map(MavenProject::getBasedir)
                     .map(File::toPath)
                     .map(localRepoMock.getBaseCanonicalBaseFolder().toPath()::relativize)
@@ -99,12 +97,16 @@ public abstract class BaseChangedProjectsTest extends BaseRepoTest {
                 Paths.get("parent/testJarDependent")
         ));
 
-        final Set<Path> actual = underTest.get().stream()
+        final Set<Path> actual = underTest.get(config()).stream()
                 .map(MavenProject::getBasedir)
                     .map(File::toPath)
                     .map(localRepoMock.getBaseCanonicalBaseFolder().toPath()::relativize)
                 .collect(Collectors.toSet());
 
         assertEquals(expected, actual);
+    }
+
+    protected Configuration config() {
+        return new Configuration(mavenSessionMock);
     }
 }

--- a/src/test/java/com/vackosar/gitflowincrementalbuild/control/BaseDifferentFilesTest.java
+++ b/src/test/java/com/vackosar/gitflowincrementalbuild/control/BaseDifferentFilesTest.java
@@ -76,9 +76,8 @@ public abstract class BaseDifferentFilesTest extends BaseRepoTest {
         mavenSessionMock.getTopLevelProject().getProperties().putAll(projectProperties);
 
         DifferentFiles underTest = new DifferentFiles();
-        Configuration.Provider configProvider = new Configuration.Provider(mavenSessionMock);
-        GitProvider gitProvider = new GitProvider(mavenSessionMock, configProvider.get());
-        Whitebox.setInternalState(underTest, configProvider, gitProvider, loggerSpy);
+        GitProvider gitProvider = new GitProvider();
+        Whitebox.setInternalState(underTest, gitProvider, loggerSpy);
 
         // isolate a possible native git invocation from the settings of the system the test is runing on
         underTest.putAdditionalNativeGitEnvironment("GIT_CONFIG_NOSYSTEM", "1");
@@ -86,7 +85,7 @@ public abstract class BaseDifferentFilesTest extends BaseRepoTest {
 
         Set<Path> result;
         try {
-            result = underTest.get();
+            result = underTest.get(new Configuration(mavenSessionMock));
         } finally {
             gitProvider.close();
         }

--- a/src/test/java/com/vackosar/gitflowincrementalbuild/jgit/GitProviderTest.java
+++ b/src/test/java/com/vackosar/gitflowincrementalbuild/jgit/GitProviderTest.java
@@ -2,35 +2,44 @@ package com.vackosar.gitflowincrementalbuild.jgit;
 
 import com.google.common.io.Files;
 import com.vackosar.gitflowincrementalbuild.boundary.Configuration;
+import com.vackosar.gitflowincrementalbuild.control.Property;
 import com.vackosar.gitflowincrementalbuild.control.jgit.GitProvider;
 import com.vackosar.gitflowincrementalbuild.entity.SkipExecutionException;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.project.MavenProject;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class GitProviderTest {
 
     @Mock
     private MavenSession mavenSessionMock;
-    @Mock
-    private Configuration configuration;
 
-    @InjectMocks
-    private GitProvider underTest;
+    private GitProvider underTest = new GitProvider();
+
+    @BeforeEach
+    public void setup() {
+        MavenProject projectMock = mock(MavenProject.class);
+        when(projectMock.getProperties()).thenReturn(new Properties());
+        projectMock.getProperties().put(Property.enabled.prefixedName(), "false"); // otherwise unrelated stuff in MavenSession would need mocking
+        when(mavenSessionMock.getTopLevelProject()).thenReturn(projectMock);
+    }
 
     @AfterEach
     public void tearDown() {
@@ -40,7 +49,7 @@ public class GitProviderTest {
     @Test
     public void test_simple() throws IOException {
         initSimple();
-        assertNotNull(underTest.get());
+        assertNotNull(underTest.get(new Configuration(mavenSessionMock)));
 
         verify(mavenSessionMock).getCurrentProject();
     }
@@ -65,6 +74,6 @@ public class GitProviderTest {
         mavenProject.setFile(pom);
         doReturn(mavenProject).when(mavenSessionMock).getCurrentProject();
 
-        assertThrows(SkipExecutionException.class, underTest::get);
+        assertThrows(SkipExecutionException.class, () -> underTest.get(new Configuration(mavenSessionMock)));
     }
 }


### PR DESCRIPTION
Fixes #204

Removes usage auf injected MavenSession which is inconsistent in IntelliJ IDEA.
The MavenSession that is passed to the LifecycleParticipant is used instead.

Second commit: Be extra defensive when getting project properties
By falling back to currentProject and if even that is null, log a warning and auto-disable.