### PR TITLE
Introduce 'disable' property and deprecate 'enabled' property

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This extension is **not limited to Git Flow setups!** The [extensive configurati
 
 - [Configuration](#configuration)
   - [gib.help](#gibhelp)
-  - [gib.enabled](#gibenabled)
+  - [gib.disable](#gibdisable)
   - [gib.disableIfBranchRegex](#gibdisableifbranchregex)
   - [gib.disableBranchComparison](#gibdisablebranchcomparison)
   - [gib.referenceBranch](#gibreferencebranch)
@@ -121,7 +121,7 @@ The plugin definition is merely a "shell" to provide `<profile>`-support, better
 As IDEs like IntelliJ IDEA or Eclipse usually apply their own custom strategy to building changed modules,
 this extension should be disabled in such environments to avoid inconsistencies or errors (e.g. see [issue 49](../../issues/49)).
 
-See [gib.enabled](#gibenabled) in the configuration section.
+See [gib.disable](#gibdisable) in the configuration section.
 
 :information_source: If using IntelliJ IDEA, version **2019.3.1** or higher is required for GIB 3.8+ (even if disabled).
 See [IDEA-200272](https://youtrack.jetbrains.com/issue/IDEA-200272) and [issue 91](../../issues/91) for more details.
@@ -313,7 +313,7 @@ Maven pom properties configuration with default values is below:
 ```xml
 <properties>
     <gib.help>false</gib.help>                                                         <!-- or -Dgib.h=...     -->
-    <gib.enabled>true</gib.enabled>                                                    <!-- or -Dgib.e=...     -->
+    <gib.disable>false</gib.disable>                                                   <!-- or -Dgib.d=...     -->
     <gib.disableIfBranchRegex></gib.disableIfBranchRegex>                              <!-- or -Dgib.dibr=...  -->
     <gib.disableBranchComparison>false</gib.disableBranchComparison>                   <!-- or -Dgib.dbc=...   -->
     <gib.referenceBranch>refs/remotes/origin/develop</gib.referenceBranch>             <!-- or -Dgib.rb=...    -->
@@ -343,9 +343,9 @@ Maven pom properties configuration with default values is below:
 
 Each property can also be set via `-D` on the command line and to reduce typing to a minimum, each property has a short name (see code block above).
 
-E.g. `-Dgib.e=true` yields the same result as `-Dgib.enabled=true`.
+E.g. `-Dgib.d=true` yields the same result as `-Dgib.disable=true`.
 
-Properties that support the value `true` can be specified _without_ a value, e.g. `-Dgib.enabled` is the same as `-Dgib.enabled=true`.
+Properties that support the value `true` can be specified _without_ a value, e.g. `-Dgib.disable` is the same as `-Dgib.disable=true`.
 
 System properties (`-D`) take precedence over project properties from the POM and secondarily to that a full name takes precedence over the respective short name.<br/>
 Short names can only be used as system properties.
@@ -369,13 +369,15 @@ use:
 
 Logs the available properties etc.
 
-Note: Independent of `gib.enabled`.
+Note: Independent of `gib.disable`.
 
 Since: 3.9.0
 
-### gib.enabled
+### gib.disable
 
 Can be used to disable this extension temporarily or permanently (e.g. to avoid clashes with IDE building strategy).
+
+Since: 3.11.2 (replaces previously used `enabled` property)
 
 ### gib.disableIfBranchRegex
 

--- a/pom.xml
+++ b/pom.xml
@@ -622,12 +622,14 @@
                     </execution>
                     <execution>
                         <id>jacoco-report</id>
+                        <phase>test</phase> <!-- integration-tests are not using jacoco -->
                         <goals>
                             <goal>report</goal>
                         </goals>
                     </execution>
                     <execution>
                         <id>jacoco-check</id>
+                        <phase>test</phase> <!-- integration-tests are not using jacoco -->
                         <goals>
                             <goal>check</goal>
                         </goals>

--- a/src/main/java/com/vackosar/gitflowincrementalbuild/boundary/Configuration.java
+++ b/src/main/java/com/vackosar/gitflowincrementalbuild/boundary/Configuration.java
@@ -38,7 +38,7 @@ public class Configuration {
     public final MavenSession mavenSession;
 
     public final boolean help;
-    public final boolean enabled;
+    public final boolean disable;
     public final Optional<Predicate<String>> disableIfBranchRegex;
 
     public final boolean disableBranchComparison;
@@ -75,8 +75,9 @@ public class Configuration {
         Properties pluginProperties = properties[1];
 
         help = Boolean.parseBoolean(Property.help.getValue(pluginProperties, projectProperties));
-        enabled = Boolean.parseBoolean(Property.enabled.getValue(pluginProperties, projectProperties));
-        if (!enabled) { // abort parsing any other config properties if not enabled at all
+        disable = Boolean.parseBoolean(Property.disable.getValue(pluginProperties, projectProperties))
+                || !Boolean.parseBoolean(Property.enabled.getValue(pluginProperties, projectProperties));
+        if (disable) { // abort parsing any other config properties if not enabled at all
             disableIfBranchRegex = null;
 
             // change detection config
@@ -180,7 +181,7 @@ public class Configuration {
         } else {
             logger.warn("gitflow-incremental-builder could not parse configuration due to missing 'topLevel' or 'current' project in the MavenSession.");
             Properties fakeProjectProperties = new Properties();
-            fakeProjectProperties.put(Property.enabled.prefixedName(), Boolean.FALSE.toString());
+            fakeProjectProperties.put(Property.disable.prefixedName(), Boolean.TRUE.toString());
             return new Properties[] { fakeProjectProperties, new Properties() };
         }
     }

--- a/src/main/java/com/vackosar/gitflowincrementalbuild/boundary/MavenLifecycleParticipant.java
+++ b/src/main/java/com/vackosar/gitflowincrementalbuild/boundary/MavenLifecycleParticipant.java
@@ -46,7 +46,7 @@ public class MavenLifecycleParticipant extends AbstractMavenLifecycleParticipant
             logHelp();
         }
 
-        if (!config.enabled) {
+        if (config.disable) {
             logger.info("gitflow-incremental-builder is disabled.");
             return;
         }
@@ -55,7 +55,7 @@ public class MavenLifecycleParticipant extends AbstractMavenLifecycleParticipant
         if (session.getProjectDependencyGraph() == null) {
             logger.warn("Execution of gitflow-incremental-builder is not supported in this environment: "
                     + "Current MavenSession does not provide a ProjectDependencyGraph. "
-                    + "Consider disabling gitflow-incremental-builder via property '" + Property.enabled.name() + "'.");
+                    + "Consider disabling gitflow-incremental-builder via property '" + Property.disable.name() + "'.");
             return;
         }
 

--- a/src/test/java/com/vackosar/gitflowincrementalbuild/boundary/ConfigurationTest.java
+++ b/src/test/java/com/vackosar/gitflowincrementalbuild/boundary/ConfigurationTest.java
@@ -73,33 +73,33 @@ public class ConfigurationTest {
     }
 
     @Test
-    public void enabled() {
-        System.setProperty(Property.enabled.prefixedName(), "false");
+    public void disable() {
+        System.setProperty(Property.disable.prefixedName(), "true");
 
         Configuration configuration = new Configuration(mavenSessionMock);
 
-        assertFalse(configuration.enabled);
+        assertTrue(configuration.disable);
         assertNull(configuration.disableIfBranchRegex);
     }
 
     @Test
-    public void enabled_projectProperties() {
-        projectProperties.put(Property.enabled.prefixedName(), "false");
+    public void disable_projectProperties() {
+        projectProperties.put(Property.disable.prefixedName(), "true");
 
         Configuration configuration = new Configuration(mavenSessionMock);
 
-        assertFalse(configuration.enabled);
+        assertTrue(configuration.disable);
         assertNull(configuration.disableIfBranchRegex);
     }
 
     @Test
-    public void enabled_projectProperties_overriddenBySystemProperty() {
-        projectProperties.put(Property.enabled.prefixedName(), "true");
-        System.setProperty(Property.enabled.prefixedName(), "false");
+    public void disable_projectProperties_overriddenBySystemProperty() {
+        projectProperties.put(Property.disable.prefixedName(), "false");
+        System.setProperty(Property.disable.prefixedName(), "true");
 
         Configuration configuration = new Configuration(mavenSessionMock);
 
-        assertFalse(configuration.enabled);
+        assertTrue(configuration.disable);
         assertNull(configuration.disableIfBranchRegex);
     }
 
@@ -431,7 +431,7 @@ public class ConfigurationTest {
 
         Configuration configuration = new Configuration(mavenSessionMock);
 
-        assertFalse(configuration.enabled);
+        assertTrue(configuration.disable);
     }
 
     @Test
@@ -441,7 +441,25 @@ public class ConfigurationTest {
 
         Configuration configuration = new Configuration(mavenSessionMock);
 
-        assertTrue(configuration.enabled);
+        assertFalse(configuration.disable);
+    }
+
+    @Test
+    public void enabled_systemProperty() {
+        System.setProperty(Property.enabled.prefixedName(), "false");
+
+        Configuration configuration = new Configuration(mavenSessionMock);
+
+        assertTrue(configuration.disable);
+    }
+
+    @Test
+    public void enabled_systemProperty_shortName() {
+        System.setProperty(Property.enabled.prefixedShortName(), "false");
+
+        Configuration configuration = new Configuration(mavenSessionMock);
+
+        assertTrue(configuration.disable);
     }
 
     private void mockPluginConfig(String propertyName, String value) {

--- a/src/test/java/com/vackosar/gitflowincrementalbuild/boundary/MavenLifecycleParticipantTest.java
+++ b/src/test/java/com/vackosar/gitflowincrementalbuild/boundary/MavenLifecycleParticipantTest.java
@@ -78,7 +78,7 @@ public class MavenLifecycleParticipantTest {
 
     @Test
     public void disabled() throws Exception {
-        projectProperties.setProperty(Property.enabled.prefixedName(), "false");
+        projectProperties.setProperty(Property.disable.prefixedName(), "true");
 
         underTest.afterProjectsRead(mavenSessionMock);
 
@@ -89,7 +89,7 @@ public class MavenLifecycleParticipantTest {
 
     @Test
     public void disabled_helpRequested() throws Exception {
-        projectProperties.setProperty(Property.enabled.prefixedName(), "false");
+        projectProperties.setProperty(Property.disable.prefixedName(), "true");
         projectProperties.setProperty(Property.help.prefixedName(), "true");
 
         underTest.afterProjectsRead(mavenSessionMock);

--- a/src/test/java/com/vackosar/gitflowincrementalbuild/control/PropertyTest.java
+++ b/src/test/java/com/vackosar/gitflowincrementalbuild/control/PropertyTest.java
@@ -42,21 +42,21 @@ public class PropertyTest implements WithAssertions {
 
     @Test
     public void getValue_unset() {
-        assertEquals("true", Property.enabled.getValue(NO_PROPS, NO_PROPS));
+        assertEquals("false", Property.disable.getValue(NO_PROPS, NO_PROPS));
     }
 
     // prefixedName
 
     @Test
     public void getValue_prefixedName_projectProperties() {
-        assertEquals("false", Property.enabled.getValue(NO_PROPS, propsWith(Property.enabled.prefixedName(), "false")));
+        assertEquals("true", Property.disable.getValue(NO_PROPS, propsWith(Property.disable.prefixedName(), "true")));
     }
 
     @Test
     public void getValue_prefixedName_systemProperties() {
-        System.setProperty(Property.enabled.prefixedName(), "false");
+        System.setProperty(Property.disable.prefixedName(), "true");
 
-        assertEquals("false", Property.enabled.getValue(NO_PROPS, NO_PROPS));
+        assertEquals("true", Property.disable.getValue(NO_PROPS, NO_PROPS));
     }
 
     @Test
@@ -76,16 +76,16 @@ public class PropertyTest implements WithAssertions {
 
     @Test
     public void getValue_prefixedName_systemProperties_override() {
-        System.setProperty(Property.enabled.prefixedName(), "true");
+        System.setProperty(Property.disable.prefixedName(), "false");
 
-        assertEquals("true", Property.enabled.getValue(NO_PROPS, propsWith(Property.enabled.prefixedName(), "false")));
+        assertEquals("false", Property.disable.getValue(NO_PROPS, propsWith(Property.disable.prefixedName(), "true")));
     }
 
     @Test
     public void getValue_prefixedName_systemProperties_override_prefixedShortName() {
-        System.setProperty(Property.enabled.prefixedShortName(), "true");
+        System.setProperty(Property.disable.prefixedShortName(), "false");
 
-        assertEquals("true", Property.enabled.getValue(NO_PROPS, propsWith(Property.enabled.prefixedName(), "false")));
+        assertEquals("false", Property.disable.getValue(NO_PROPS, propsWith(Property.disable.prefixedName(), "true")));
     }
 
     // prefixedShortName
@@ -93,55 +93,55 @@ public class PropertyTest implements WithAssertions {
     @Test
     public void getValue_prefixedShortName_projectProperties() {
         // short name will only be resolved from system properties!
-        assertEquals("true", Property.enabled.getValue(NO_PROPS, propsWith(Property.enabled.prefixedShortName(), "false")));
+        assertEquals("false", Property.disable.getValue(NO_PROPS, propsWith(Property.disable.prefixedShortName(), "true")));
     }
 
     @Test
     public void getValue_prefixedShortName_systemProperties() {
-        System.setProperty(Property.enabled.prefixedShortName(), "false");
+        System.setProperty(Property.disable.prefixedShortName(), "true");
 
-        assertEquals("false", Property.enabled.getValue(NO_PROPS, NO_PROPS));
+        assertEquals("true", Property.disable.getValue(NO_PROPS, NO_PROPS));
     }
 
     @Test
     public void getValue_prefixedShortName_systemProperties_override() {
-        System.setProperty(Property.enabled.prefixedShortName(), "true");
+        System.setProperty(Property.disable.prefixedShortName(), "false");
 
-        assertEquals("true", Property.enabled.getValue(NO_PROPS, propsWith(Property.enabled.prefixedShortName(), "false")));
+        assertEquals("false", Property.disable.getValue(NO_PROPS, propsWith(Property.disable.prefixedShortName(), "true")));
     }
 
     @Test
     public void getValue_prefixedShortName_systemProperties_override_prefixedNameWins() {
-        System.setProperty(Property.enabled.prefixedName(), "false");
-        System.setProperty(Property.enabled.prefixedShortName(), "true");
+        System.setProperty(Property.disable.prefixedName(), "true");
+        System.setProperty(Property.disable.prefixedShortName(), "false");
 
-        assertEquals("false", Property.enabled.getValue(NO_PROPS, NO_PROPS));
+        assertEquals("true", Property.disable.getValue(NO_PROPS, NO_PROPS));
     }
 
     // name (plugin mode)
 
     @Test
     public void getValue_pluginProperties() {
-        assertEquals("false", Property.enabled.getValue(propsWith(Property.enabled.name(), "false"), NO_PROPS));
+        assertEquals("true", Property.disable.getValue(propsWith(Property.disable.name(), "true"), NO_PROPS));
     }
 
     @Test
     public void getValue_pluginProperties_overridesProjectProperties() {
-        assertEquals("false", Property.enabled.getValue(propsWith(Property.enabled.name(), "false"), propsWith(Property.enabled.name(), "true")));
+        assertEquals("true", Property.disable.getValue(propsWith(Property.disable.name(), "true"), propsWith(Property.disable.name(), "false")));
     }
 
     @Test
     public void getValue_pluginProperties_systemProperties_override() {
-        System.setProperty(Property.enabled.prefixedName(), "true");
+        System.setProperty(Property.disable.prefixedName(), "false");
 
-        assertEquals("true", Property.enabled.getValue(propsWith(Property.enabled.name(), "false"), NO_PROPS));
+        assertEquals("false", Property.disable.getValue(propsWith(Property.disable.name(), "true"), NO_PROPS));
     }
 
     @Test
     public void getValue_pluginProperties_systemProperties_overrideWithPrefixedShortName() {
-        System.setProperty(Property.enabled.prefixedShortName(), "true");
+        System.setProperty(Property.disable.prefixedShortName(), "false");
 
-        assertEquals("true", Property.enabled.getValue(propsWith(Property.enabled.name(), "false"), NO_PROPS));
+        assertEquals("false", Property.disable.getValue(propsWith(Property.disable.name(), "true"), NO_PROPS));
     }
 
     // misc
@@ -168,7 +168,7 @@ public class PropertyTest implements WithAssertions {
 
     @Test
     public void checkProperties_ok() {
-        System.setProperty(Property.enabled.prefixedName(), "");
+        System.setProperty(Property.disable.prefixedName(), "");
         System.setProperty(Property.disableBranchComparison.prefixedShortName(), "true");
 
         Property.checkProperties(propsWith(Property.disableIfBranchRegex.name(), "master"),
@@ -192,7 +192,7 @@ public class PropertyTest implements WithAssertions {
 
     @Test
     public void getDefaultValue_sample() {
-        assertThat(Property.enabled.getDefaultValue()).isEqualTo("true");
+        assertThat(Property.disable.getDefaultValue()).isEqualTo("false");
     }
 
     @Test
@@ -202,7 +202,7 @@ public class PropertyTest implements WithAssertions {
 
     @Test
     public void isBoolean_samples() {
-        assertThat(Property.enabled.isBoolean()).isTrue();
+        assertThat(Property.disable.isBoolean()).isTrue();
         assertThat(Property.referenceBranch.isBoolean()).isFalse();
     }
 

--- a/src/test/java/com/vackosar/gitflowincrementalbuild/integration/MavenIntegrationTestBase.java
+++ b/src/test/java/com/vackosar/gitflowincrementalbuild/integration/MavenIntegrationTestBase.java
@@ -113,9 +113,10 @@ public abstract class MavenIntegrationTestBase extends BaseRepoTest {
             return;
         }
         copyCommonBuildParentPom();
-        executeBuild(true, false, "--file=build-parent/pom-common.xml", prop(Property.enabled, "false"));
-        executeBuild(true, false, "--file=build-parent/pom.xml", prop(Property.enabled, "false"));
-        executeBuild(true, false, DEFAULT_POMFILE_ARG, prop(Property.enabled, "false"));
+        String disableGib = prop(Property.disable, "true");
+        executeBuild(true, false, "--file=build-parent/pom-common.xml", disableGib);
+        executeBuild(true, false, "--file=build-parent/pom.xml", disableGib);
+        executeBuild(true, false, DEFAULT_POMFILE_ARG, disableGib);
         INITIAL_INSTALL_DONE.add(testClass);
     }
 

--- a/src/test/java/com/vackosar/gitflowincrementalbuild/integration/MavenPluginIntegrationTest.java
+++ b/src/test/java/com/vackosar/gitflowincrementalbuild/integration/MavenPluginIntegrationTest.java
@@ -35,7 +35,7 @@ public class MavenPluginIntegrationTest extends MavenIntegrationTestBase {
         final String output = executeBuild(
                 "help:describe",
                 "-Dplugin=" + Configuration.PLUGIN_KEY + ":" + gibVersion,
-                "-Ddetail", prop(Property.enabled, "false"),
+                "-Ddetail", prop(Property.disable, "true"),
                 "-N");
         assertThat(output).contains("This plugin has 1 goal:");
         assertThat(output).contains(MojoParametersGeneratingByteBuddyPlugin.FAKE_MOJO_NAME);

--- a/src/test/java/com/vackosar/gitflowincrementalbuild/jgit/GitProviderTest.java
+++ b/src/test/java/com/vackosar/gitflowincrementalbuild/jgit/GitProviderTest.java
@@ -41,7 +41,7 @@ public class GitProviderTest {
     public void setup() {
         MavenProject projectMock = mock(MavenProject.class);
         when(projectMock.getProperties()).thenReturn(new Properties());
-        projectMock.getProperties().put(Property.enabled.prefixedName(), "false"); // otherwise unrelated stuff in MavenSession would need mocking
+        projectMock.getProperties().put(Property.disable.prefixedName(), "true"); // otherwise unrelated stuff in MavenSession would need mocking
         when(mavenSessionMock.getTopLevelProject()).thenReturn(projectMock);
     }
 


### PR DESCRIPTION
This is more alinged to `disableIfBranchRegex` and is more logical since GIB shall be active by default.
Furthermore, `-Dgib.d` is shorter than `-Dgib.e=false`.