### PR TITLE
Rename property 'uncommited' to 'uncommitted'

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This extension is **not limited to Git Flow setups!** The [extensive configurati
   - [gib.fetchBaseBranch](#gibfetchbasebranch)
   - [gib.useJschAgentProxy](#gibusejschagentproxy)
   - [gib.compareToMergeBase](#gibcomparetomergebase)
-  - [gib.uncommited](#gibuncommited)
+  - [gib.uncommitted](#gibuncommitted)
   - [gib.untracked](#gibuntracked)
   - [gib.excludePathRegex](#gibexcludePathRegex)
   - [gib.includePathRegex](#gibincludepathregex)
@@ -321,7 +321,7 @@ Maven pom properties configuration with default values is below:
     <gib.fetchBaseBranch>false</gib.fetchBaseBranch>                                   <!-- or -Dgib.fbb=...   -->
     <gib.useJschAgentProxy>true</gib.useJschAgentProxy>                                <!-- or -Dgib.ujap=...  -->
     <gib.compareToMergeBase>true</gib.compareToMergeBase>                              <!-- or -Dgib.ctmb=...  -->
-    <gib.uncommited>true</gib.uncommited>                                              <!-- or -Dgib.uc=...    -->
+    <gib.uncommitted>true</gib.uncommitted>                                            <!-- or -Dgib.uc=...    -->
     <gib.untracked>true</gib.untracked>                                                <!-- or -Dgib.ut=...    -->
     <gib.excludePathRegex></gib.excludePathRegex>                                      <!-- or -Dgib.epr=...   -->
     <gib.includePathRegex></gib.includePathRegex>                                      <!-- or -Dgib.ipr=...   -->
@@ -354,16 +354,16 @@ to put the properties into the plugin `<configuration>`-section, but _without_ t
 E.g. instead of:
 ```xml
 <properties>
-    <gib.uncommited>true</gib.uncommited>
+    <gib.uncommitted>true</gib.uncommitted>
 </properties>
 ```
 use:
 ```xml
 <configuration>
-    <uncommited>true</uncommited>
+    <uncommitted>true</uncommitted>
 </configuration>
 ```
-Just like for regular plugins, a plugin config property that is set to a _fixed_ value **cannot be changed via the respective system property** (here: `-Dgib.uncommited=false`).
+Just like for regular plugins, a plugin config property that is set to a _fixed_ value **cannot be changed via the respective system property** (here: `-Dgib.uncommitted=false`).
 
 ### gib.help
 
@@ -387,7 +387,7 @@ Since: 3.11.0
 
 ### gib.disableBranchComparison
 
-Disables the comparison between `baseBranch` and `referenceBranch`. This property should be enabled if _only_ uncommitted and/or untracked files shall be detected to only build projects that have been changed since the last commit in the current branch (see `gib.uncommited` and `gib.untracked`).
+Disables the comparison between `baseBranch` and `referenceBranch`. This property should be enabled if _only_ uncommitted and/or untracked files shall be detected to only build projects that have been changed since the last commit in the current branch (see `gib.uncommitted` and `gib.untracked`).
 The following properties are _not_ evaluated when `gib.disableBranchComparison` is enabled:
 - `gib.referenceBranch`
 - `gib.compareToMergeBase`
@@ -440,7 +440,7 @@ Since: 3.9.1
 
 Controls whether or not to the [merge-base](https://git-scm.com/docs/git-merge-base) mechanism to compare the branches.
 
-### gib.uncommited
+### gib.uncommitted
 
 Detects changed files that have not yet been committed. This does **not** include _untracked_ files (see `git status` manual).
 

--- a/src/main/java/com/vackosar/gitflowincrementalbuild/boundary/Configuration.java
+++ b/src/main/java/com/vackosar/gitflowincrementalbuild/boundary/Configuration.java
@@ -48,7 +48,7 @@ public class Configuration {
     public final boolean fetchBaseBranch;
     public final boolean useJschAgentProxy;
     public final boolean compareToMergeBase;
-    public final boolean uncommited;
+    public final boolean uncommitted;
     public final boolean untracked;
     public final Optional<Predicate<String>> excludePathRegex;
     public final Optional<Predicate<String>> includePathRegex;
@@ -89,7 +89,7 @@ public class Configuration {
             fetchBaseBranch = false;
             useJschAgentProxy = false;
             compareToMergeBase = false;
-            uncommited = false;
+            uncommitted = false;
             untracked = false;
             excludePathRegex = null;
             includePathRegex = null;
@@ -130,7 +130,7 @@ public class Configuration {
         fetchBaseBranch = Boolean.valueOf(Property.fetchBaseBranch.getValue(pluginProperties, projectProperties));
         useJschAgentProxy = Boolean.valueOf(Property.useJschAgentProxy.getValue(pluginProperties, projectProperties));
         compareToMergeBase = Boolean.valueOf(Property.compareToMergeBase.getValue(pluginProperties, projectProperties));
-        uncommited = Boolean.valueOf(Property.uncommited.getValue(pluginProperties, projectProperties));
+        uncommitted = Boolean.valueOf(Property.uncommitted.getValue(pluginProperties, projectProperties));
         untracked = Boolean.valueOf(Property.untracked.getValue(pluginProperties, projectProperties));
         excludePathRegex = compileOptionalPatternPredicate(Property.excludePathRegex, pluginProperties, projectProperties);
         includePathRegex = compileOptionalPatternPredicate(Property.includePathRegex, pluginProperties, projectProperties);

--- a/src/main/java/com/vackosar/gitflowincrementalbuild/control/DifferentFiles.java
+++ b/src/main/java/com/vackosar/gitflowincrementalbuild/control/DifferentFiles.java
@@ -63,7 +63,7 @@ public class DifferentFiles {
             if (!config.disableBranchComparison) {
                 paths.addAll(worker.getBranchDiff());
             }
-            if (config.uncommited || config.untracked) {
+            if (config.uncommitted || config.untracked) {
                 paths.addAll(worker.getChangesFromStatus());
             }
         } finally {
@@ -204,7 +204,7 @@ public class DifferentFiles {
         private Set<Path> getChangesFromStatus() throws GitAPIException {
             Set<String> changes = new HashSet<>();
             Status status = git.status().call();
-            if (configuration.uncommited) {
+            if (configuration.uncommitted) {
                 changes.addAll(status.getUncommittedChanges());
             }
             if (configuration.untracked) {

--- a/src/main/java/com/vackosar/gitflowincrementalbuild/control/Property.java
+++ b/src/main/java/com/vackosar/gitflowincrementalbuild/control/Property.java
@@ -80,7 +80,12 @@ public enum Property {
     /**
      * Detects changed files that have not yet been committed.
      */
-    uncommited("true", "uc", true),
+    uncommitted("true", "uc", true) {
+        @Override
+        public Optional<String> deprecatedName() {
+            return Optional.of("uncommited");
+        }
+    },
     /**
      * Detects files that are not yet tracked by git.
      */
@@ -171,7 +176,7 @@ public enum Property {
         this.nameCandidatesForSystemProperties = Stream.of(prefixedName, prefixedShortName, deprecatedPrefixedName())
                 .filter(Objects::nonNull)
                 .collect(Collectors.collectingAndThen(Collectors.toList(), Collections::unmodifiableList));
-        this.nameCandidatesForPluginProperties = Stream.of(name(), deprecatedName())
+        this.nameCandidatesForPluginProperties = Stream.of(name(), deprecatedName().orElse(null))
                 .filter(Objects::nonNull)
                 .collect(Collectors.collectingAndThen(Collectors.toList(), Collections::unmodifiableList));
         this.nameCandidatesForProjectProperties = Stream.of(prefixedName, deprecatedPrefixedName())
@@ -203,16 +208,16 @@ public enum Property {
     /**
      * @return the deprecated unprefixed name or {@code null} if there is no such deprecated name for this property
      */
-    public String deprecatedName() {
+    public Optional<String> deprecatedName() {
         // might be overridden by specific enum instances
-        return null;
+        return Optional.empty();
     }
 
     /**
      * @return the deprecated prefixed name or {@code null} if there is no such deprecated name for this property
      */
     public final String deprecatedPrefixedName() {
-        return Optional.ofNullable(deprecatedName()).map(PREFIX::concat).orElse(null);
+        return deprecatedName().map(PREFIX::concat).orElse(null);
     }
 
     public ValueWithOriginContext getValueWithOriginContext(Properties pluginProperties, Properties projectProperties) {
@@ -262,7 +267,7 @@ public enum Property {
             return null;
         }
         boolean prefixed = name.startsWith(PREFIX);
-        String deprecatedName = prefixed ? deprecatedPrefixedName() : deprecatedName();
+        String deprecatedName = prefixed ? deprecatedPrefixedName() : deprecatedName().orElse(null);
         if (name.equals(deprecatedName)) {
             LOGGER.warn("'{}' has been renamed to '{}' and the old name will be removed in an upcoming release. Please adjust your configuration!",
                     deprecatedName, prefixed ? prefixedName : name());

--- a/src/main/java/com/vackosar/gitflowincrementalbuild/mojo/MojoParametersGeneratingByteBuddyPlugin.java
+++ b/src/main/java/com/vackosar/gitflowincrementalbuild/mojo/MojoParametersGeneratingByteBuddyPlugin.java
@@ -3,7 +3,6 @@ package com.vackosar.gitflowincrementalbuild.mojo;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Modifier;
-
 import org.apache.maven.plugins.annotations.InstantiationStrategy;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -217,7 +216,7 @@ public class MojoParametersGeneratingByteBuddyPlugin implements Plugin {
 
             @Override
             public String alias() {
-                // cannot be used for the short name since in Eclipse this would then be a valid option to select (but only -D is allowed)
+                // Cannot be used for the short name since in Eclipse this would then be a valid option to select (but only -D is allowed).
                 return "";
             }
         };

--- a/src/test/java/com/vackosar/gitflowincrementalbuild/BaseRepoTest.java
+++ b/src/test/java/com/vackosar/gitflowincrementalbuild/BaseRepoTest.java
@@ -68,7 +68,7 @@ public abstract class BaseRepoTest {
     }
 
     private void init() {
-        projectProperties.setProperty(Property.uncommited.prefixedName(), "false");
+        projectProperties.setProperty(Property.uncommitted.prefixedName(), "false");
         projectProperties.setProperty(Property.untracked.prefixedName(), "false");
         projectProperties.setProperty(Property.referenceBranch.prefixedName(), "refs/heads/develop");
         projectProperties.setProperty(Property.compareToMergeBase.prefixedName(), "false");

--- a/src/test/java/com/vackosar/gitflowincrementalbuild/control/DifferentFilesTest.java
+++ b/src/test/java/com/vackosar/gitflowincrementalbuild/control/DifferentFilesTest.java
@@ -53,7 +53,7 @@ public class DifferentFilesTest extends BaseDifferentFilesTest {
     @Test
     public void listWithUncommitted() throws Exception {
         Path modifiedFilePath = modifyTrackedFile(repoPath);
-        projectProperties.setProperty(Property.uncommited.prefixedName(), "true");
+        projectProperties.setProperty(Property.uncommitted.prefixedName(), "true");
 
         assertTrue(invokeUnderTest().contains(modifiedFilePath));
     }
@@ -61,7 +61,7 @@ public class DifferentFilesTest extends BaseDifferentFilesTest {
     @Test
     public void listWithUncommitted_disabled() throws Exception {
         Path modifiedFilePath = modifyTrackedFile(repoPath);
-        projectProperties.setProperty(Property.uncommited.prefixedName(), "false");
+        projectProperties.setProperty(Property.uncommitted.prefixedName(), "false");
 
         assertFalse(invokeUnderTest().contains(modifiedFilePath));
     }
@@ -69,7 +69,7 @@ public class DifferentFilesTest extends BaseDifferentFilesTest {
     @Test
     public void listWithUncommitted_excluded() throws Exception {
         Path modifiedFilePath = modifyTrackedFile(repoPath);
-        projectProperties.setProperty(Property.uncommited.prefixedName(), "true");
+        projectProperties.setProperty(Property.uncommitted.prefixedName(), "true");
         projectProperties.setProperty(Property.excludePathRegex.prefixedName(), Pattern.quote(repoPath.relativize(modifiedFilePath).toString()));
 
         assertFalse(invokeUnderTest().contains(modifiedFilePath));

--- a/src/test/java/com/vackosar/gitflowincrementalbuild/mojo/FakeMojoTest.java
+++ b/src/test/java/com/vackosar/gitflowincrementalbuild/mojo/FakeMojoTest.java
@@ -202,8 +202,8 @@ public class FakeMojoTest implements WithAssertions {
 
     private void check(String asTextFormat, ImmutablePair<List<String>, List<String>> nodeTexts, Consumer<ProxyableListAssert<String>> assertionConsumer) {
         SoftAssertions softly = new SoftAssertions();
-        assertionConsumer.accept(softly.assertThat(nodeTexts.left) .as(asTextFormat, "plugin.xml"));
-        assertionConsumer.accept(softly.assertThat(nodeTexts.right) .as(asTextFormat, "plugin-help.xml"));
+        assertionConsumer.accept(softly.assertThat(nodeTexts.left).as(asTextFormat, "plugin.xml"));
+        assertionConsumer.accept(softly.assertThat(nodeTexts.right).as(asTextFormat, "plugin-help.xml"));
         softly.assertAll();
     }
 }


### PR DESCRIPTION
FYI @mickroll, this is an example of how we can fix typos etc. without immediately breaking clients.