### PR TITLE
Introduce disableSelectedProjectsHandling

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ This extension is **not limited to Git Flow setups!** The [extensive configurati
   - [gib.argsForUpstreamModules](#gibargsforupstreammodules)
   - [gib.forceBuildModules](#gibforcebuildmodules)
   - [gib.excludeDownstreamModulesPackagedAs](#gibexcludedownstreammodulespackagedas)
+  - [gib.disableSelectedProjectsHandling](#gibdisableselectedprojectshandling)
   - [gib.failOnMissingGitDir](#failonmissinggitdir)
   - [gib.failOnError](#gibfailonerror)
   - [gib.logImpactedTo](#giblogimpactedto)
@@ -334,6 +335,7 @@ Maven pom properties configuration with default values is below:
     <gib.argsForUpstreamModules></gib.argsForUpstreamModules>                          <!-- or -Dgib.afum=...  -->
     <gib.forceBuildModules></gib.forceBuildModules>                                    <!-- or -Dgib.fbm=...   -->
     <gib.excludeDownstreamModulesPackagedAs></gib.excludeDownstreamModulesPackagedAs>  <!-- or -Dgib.edmpa=... -->
+    <gib.disableSelectedProjectsHandling>false</gib.disableSelectedProjectsHandling>   <!-- or -Dgib.dsph=...  -->
     <gib.failOnMissingGitDir>true</gib.failOnMissingGitDir>                            <!-- or -Dgib.fomgd=... -->
     <gib.failOnError>true</gib.failOnError>                                            <!-- or -Dgib.foe=...   -->
     <gib.logImpactedTo></gib.logImpactedTo>                                            <!-- or -Dgib.lit=...   -->
@@ -578,6 +580,15 @@ deployment modules will be built.
 
 This property has no effect in case `buildAll` is enabled and an exclusion might be overriden by `gib.forceBuildModules`.
 
+### gib.disableSelectedProjectsHandling
+
+Disables special handling of [explicitly selected projects](#explicitly-selected-projects) (-pl, -f etc.).
+
+This can come in handy if you select just one module with `-pl` but you only want to have it built _fully_ (with tests etc.)
+if the selected module itself is changed or one of its (non-selected) upstream modules.
+
+Since: 3.12.0
+
 ### gib.failOnMissingGitDir
 
 Controls whether or not to fail on missing `.git` directory.
@@ -597,6 +608,10 @@ or only [explicitly selected projects](#explicitly-selected-projects) are presen
 Since: 3.10.1
 
 ## Explicitly selected projects
+
+By default, GIB tries not to interfere with any projects/modules that have been selected explicitely by the user.
+
+The details are described in the following subsections. This special handling can be disabled via [gib.disableSelectedProjectsHandling](#gibdisableSelectedProjectsHandling).
 
 ### mvn -pl
 

--- a/src/main/java/com/vackosar/gitflowincrementalbuild/boundary/Configuration.java
+++ b/src/main/java/com/vackosar/gitflowincrementalbuild/boundary/Configuration.java
@@ -62,6 +62,7 @@ public class Configuration {
     public final Map<String, String> argsForUpstreamModules;
     public final List<Pattern> forceBuildModules;
     public final List<String> excludeDownstreamModulesPackagedAs;
+    public final boolean disableSelectedProjectsHandling;
 
     public final boolean failOnMissingGitDir;
     public final boolean failOnError;
@@ -111,6 +112,8 @@ public class Configuration {
 
             excludeDownstreamModulesPackagedAs = null;
 
+            disableSelectedProjectsHandling = false;
+
             // error handling config
 
             failOnMissingGitDir = false;
@@ -126,26 +129,26 @@ public class Configuration {
 
         // change detection config
 
-        disableBranchComparison = Boolean.valueOf(Property.disableBranchComparison.getValue(pluginProperties, projectProperties));
+        disableBranchComparison = Boolean.parseBoolean(Property.disableBranchComparison.getValue(pluginProperties, projectProperties));
         referenceBranch = Property.referenceBranch.getValue(pluginProperties, projectProperties);
-        fetchReferenceBranch = Boolean.valueOf(Property.fetchReferenceBranch.getValue(pluginProperties, projectProperties));
+        fetchReferenceBranch = Boolean.parseBoolean(Property.fetchReferenceBranch.getValue(pluginProperties, projectProperties));
         baseBranch = Property.baseBranch.getValue(pluginProperties, projectProperties);
-        fetchBaseBranch = Boolean.valueOf(Property.fetchBaseBranch.getValue(pluginProperties, projectProperties));
-        useJschAgentProxy = Boolean.valueOf(Property.useJschAgentProxy.getValue(pluginProperties, projectProperties));
-        compareToMergeBase = Boolean.valueOf(Property.compareToMergeBase.getValue(pluginProperties, projectProperties));
-        uncommitted = Boolean.valueOf(Property.uncommitted.getValue(pluginProperties, projectProperties));
-        untracked = Boolean.valueOf(Property.untracked.getValue(pluginProperties, projectProperties));
+        fetchBaseBranch = Boolean.parseBoolean(Property.fetchBaseBranch.getValue(pluginProperties, projectProperties));
+        useJschAgentProxy = Boolean.parseBoolean(Property.useJschAgentProxy.getValue(pluginProperties, projectProperties));
+        compareToMergeBase = Boolean.parseBoolean(Property.compareToMergeBase.getValue(pluginProperties, projectProperties));
+        uncommitted = Boolean.parseBoolean(Property.uncommitted.getValue(pluginProperties, projectProperties));
+        untracked = Boolean.parseBoolean(Property.untracked.getValue(pluginProperties, projectProperties));
         excludePathRegex = compileOptionalPatternPredicate(Property.excludePathRegex, pluginProperties, projectProperties);
         includePathRegex = compileOptionalPatternPredicate(Property.includePathRegex, pluginProperties, projectProperties);
 
         // build config
 
-        buildAll = Boolean.valueOf(Property.buildAll.getValue(pluginProperties, projectProperties));
-        buildAllIfNoChanges = Boolean.valueOf(Property.buildAllIfNoChanges.getValue(pluginProperties, projectProperties));
+        buildAll = Boolean.parseBoolean(Property.buildAll.getValue(pluginProperties, projectProperties));
+        buildAllIfNoChanges = Boolean.parseBoolean(Property.buildAllIfNoChanges.getValue(pluginProperties, projectProperties));
         buildDownstream = isBuildStreamActive(
                 Property.buildDownstream, pluginProperties, projectProperties, session, MavenExecutionRequest.REACTOR_MAKE_DOWNSTREAM);
         buildUpstreamMode = parseBuildUpstreamMode(session, pluginProperties, projectProperties);
-        skipTestsForUpstreamModules = Boolean.valueOf(Property.skipTestsForUpstreamModules.getValue(pluginProperties, projectProperties));
+        skipTestsForUpstreamModules = Boolean.parseBoolean(Property.skipTestsForUpstreamModules.getValue(pluginProperties, projectProperties));
 
         argsForUpstreamModules = parseDelimited(Property.argsForUpstreamModules.getValue(pluginProperties, projectProperties), " ")
                 .map(Configuration::keyValueStringToEntry)
@@ -158,10 +161,12 @@ public class Configuration {
         excludeDownstreamModulesPackagedAs = parseDelimited(Property.excludeDownstreamModulesPackagedAs.getValue(pluginProperties, projectProperties), ",")
                 .collect(collectingAndThen(toList(), Collections::unmodifiableList));
 
+        disableSelectedProjectsHandling = Boolean.parseBoolean(Property.disableSelectedProjectsHandling.getValue(pluginProperties, projectProperties));
+
         // error handling config
 
-        failOnMissingGitDir = Boolean.valueOf(Property.failOnMissingGitDir.getValue(pluginProperties, projectProperties));
-        failOnError = Boolean.valueOf(Property.failOnError.getValue(pluginProperties, projectProperties));
+        failOnMissingGitDir = Boolean.parseBoolean(Property.failOnMissingGitDir.getValue(pluginProperties, projectProperties));
+        failOnError = Boolean.parseBoolean(Property.failOnError.getValue(pluginProperties, projectProperties));
         logImpactedTo = Property.logImpactedTo.getValueOpt(pluginProperties, projectProperties).map(Paths::get);
     }
 

--- a/src/main/java/com/vackosar/gitflowincrementalbuild/control/Property.java
+++ b/src/main/java/com/vackosar/gitflowincrementalbuild/control/Property.java
@@ -135,6 +135,10 @@ public enum Property {
      * Defines the packaging (e.g. jar) of modules that depend on changed modules but shall not be built.
      */
     excludeDownstreamModulesPackagedAs("", "edmpa"),
+    /**
+     * Disables special handling of explicitly selected projects (-pl, -f etc.).
+     */
+    disableSelectedProjectsHandling("false", "dsph", true),
 
     /**
      * Controls whether or not to fail on missing .git directory.


### PR DESCRIPTION
Opts out of the default "non-interference" policy regarding "explicitly selected projects".

@gastaldi This should be the solution for the problem mentioned here: https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/gitflow-incremental-builder.20%28GIB%29/near/208633072

/cc @mickroll (I think I'll merge this very soon, but you are welcome to have a look after it has been merged.)