### PR TITLE
Retain project order also when no forceBuildModules are present

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -639,7 +639,7 @@
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.82</minimum>
+                                            <minimum>0.83</minimum>
                                         </limit>
                                         <limit>
                                             <counter>CLASS</counter>

--- a/src/main/java/com/vackosar/gitflowincrementalbuild/control/ChangedProjects.java
+++ b/src/main/java/com/vackosar/gitflowincrementalbuild/control/ChangedProjects.java
@@ -39,7 +39,7 @@ public class ChangedProjects {
     private MavenProject findProject(Path diffPath, Map<Path, MavenProject> modulesPathMap) {
         Path path = diffPath;
         // Files.exist() to spot changes in non-reactor module (path will then yield a null changedReactorProject).
-        // Without this check, the changed would be wrongly mapped to the "closest" reactor module (which hasn't changed at all!).
+        // Without this check, the changed path would be wrongly mapped to the "closest" reactor module (which might not have changed at all!).
         while (path != null && !modulesPathMap.containsKey(path) && !Files.exists(path.resolve("pom.xml"))) {
             path = path.getParent();
         }

--- a/src/test/java/com/vackosar/gitflowincrementalbuild/boundary/BaseUnchangedProjectsRemoverTest.java
+++ b/src/test/java/com/vackosar/gitflowincrementalbuild/boundary/BaseUnchangedProjectsRemoverTest.java
@@ -77,6 +77,11 @@ public abstract class BaseUnchangedProjectsRemoverTest {
      */
     private final List<MavenProject> projects = new ArrayList<>();
 
+    /**
+     * Value for {@code mavenSessionMock.getAllProjects()}.
+     */
+    private final List<MavenProject> allProjects = new ArrayList<>();
+
     // gibProperties to be applied to _every_ moduleMock
     // note: at regular runtime (via Maven), each module will automatically contain the properties of its parent(s),
     //       which has to be emulated here, even though this test does not (yet) have an explicit root project
@@ -93,6 +98,7 @@ public abstract class BaseUnchangedProjectsRemoverTest {
         when(mavenExecutionRequestMock.isRecursive()).thenReturn(true);
         when(mavenSessionMock.getRequest()).thenReturn(mavenExecutionRequestMock);
         when(mavenSessionMock.getProjects()).thenReturn(projects);
+        when(mavenSessionMock.getAllProjects()).thenReturn(allProjects);
         when(mavenSessionMock.getProjectDependencyGraph()).thenReturn(projectDependencyGraphMock);
         when(changedProjectsMock.get(any(Configuration.class))).thenReturn(changedProjects);
 
@@ -115,6 +121,7 @@ public abstract class BaseUnchangedProjectsRemoverTest {
             changedProjects.add(newModuleMock);
         }
         projects.add(newModuleMock);    // add to projects that are seen by the session, which can be changed afterwards via overrideProjects()
+        allProjects.add(newModuleMock);
 
         when(newModuleMock.getProperties()).thenReturn(new Properties());
         newModuleMock.getProperties().putAll(gibProperties);
@@ -152,6 +159,7 @@ public abstract class BaseUnchangedProjectsRemoverTest {
     protected void overrideProjects(MavenProject... moduleMocks) {
         projects.clear();
         projects.addAll(Arrays.asList(moduleMocks));
+        // note: allProject always contains _all_ modules!
 
         // Maven shifts currentProject to the first(!) project (as per Maven 3.6.3 with -pl and -f)
         MavenProject firstProject = moduleMocks[0];

--- a/src/test/java/com/vackosar/gitflowincrementalbuild/boundary/LazyMavenProjectComparatorTest.java
+++ b/src/test/java/com/vackosar/gitflowincrementalbuild/boundary/LazyMavenProjectComparatorTest.java
@@ -1,0 +1,112 @@
+package com.vackosar.gitflowincrementalbuild.boundary;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.vackosar.gitflowincrementalbuild.boundary.UnchangedProjectsRemover.LazyMavenProjectComparator;
+
+@ExtendWith(MockitoExtension.class)
+public class LazyMavenProjectComparatorTest {
+
+    @Mock
+    private MavenSession mavenSessionMock;
+
+    @InjectMocks
+    private LazyMavenProjectComparator underTest;
+
+    @Test
+    public void bothNull() {
+        assertThat(underTest.compare(null, null)).isEqualTo(0);
+    }
+
+    @Test
+    public void firstNull() {
+        MavenProject second = new MavenProject();
+        when(mavenSessionMock.getProjects()).thenReturn(Collections.singletonList(second));
+
+        assertThat(underTest.compare(null, second)).isEqualTo(1);
+    }
+
+    @Test
+    public void secondNull() {
+        MavenProject first = new MavenProject();
+        when(mavenSessionMock.getProjects()).thenReturn(Collections.singletonList(first));
+
+        assertThat(underTest.compare(first, null)).isEqualTo(-1);
+    }
+
+    @Test
+    public void firstBeforeSecond() {
+        MavenProject first = projWithAid("first");
+        MavenProject second = projWithAid("second");
+        when(mavenSessionMock.getProjects()).thenReturn(Arrays.asList(first, second));
+
+        assertThat(underTest.compare(first, second)).isEqualTo(-1);
+    }
+
+    @Test
+    public void secondAfterFirst() {
+        MavenProject first = projWithAid("first");
+        MavenProject second = projWithAid("second");
+        when(mavenSessionMock.getProjects()).thenReturn(Arrays.asList(first, second));
+
+        assertThat(underTest.compare(second, first)).isEqualTo(1);
+    }
+
+    @Test
+    public void same() {
+        MavenProject first = projWithAid("first");
+        MavenProject second = projWithAid("second");
+        when(mavenSessionMock.getProjects()).thenReturn(Arrays.asList(first, second));
+
+        assertThat(underTest.compare(first, first)).isEqualTo(0);
+    }
+
+    @Test
+    public void indexMapIsRetained() {
+        assertThat(underTest.compare(null, null)).isEqualTo(0);
+
+        verify(mavenSessionMock).getProjects();
+
+        assertThat(underTest.compare(null, null)).isEqualTo(0);
+
+        verify(mavenSessionMock).getProjects(); // still only once, from the first call!
+    }
+
+    @Test
+    public void nonReactorAfterReactor() {
+        MavenProject nonReactor = projWithAid("nonReactor");
+        MavenProject reactor = projWithAid("reactor");
+        when(mavenSessionMock.getProjects()).thenReturn(Collections.singletonList(reactor));
+        when(mavenSessionMock.getAllProjects()).thenReturn(Arrays.asList(nonReactor, reactor));
+
+        assertThat(underTest.compare(nonReactor, reactor)).isEqualTo(1);
+    }
+
+    @Test
+    public void secondNonReactoAfterFirstNonReactor() {
+        MavenProject first = projWithAid("first");
+        MavenProject second = projWithAid("second");
+        when(mavenSessionMock.getAllProjects()).thenReturn(Arrays.asList(first, second));
+
+        assertThat(underTest.compare(second, first)).isEqualTo(1);
+    }
+
+    private MavenProject projWithAid(String artifactId) {
+        MavenProject proj = new MavenProject();
+        proj.setArtifactId(artifactId);
+        return proj;
+    }
+}


### PR DESCRIPTION
Introduces a comparator to be used wherever the order is important.