### PR TITLE
Avoid duplicate fields and annotations in ByteBuddy plugin

### DIFF
--- a/src/main/java/com/vackosar/gitflowincrementalbuild/mojo/MojoParametersGeneratingByteBuddyPlugin.java
+++ b/src/main/java/com/vackosar/gitflowincrementalbuild/mojo/MojoParametersGeneratingByteBuddyPlugin.java
@@ -70,9 +70,11 @@ public class MojoParametersGeneratingByteBuddyPlugin implements Plugin {
     @Override
     public Builder<?> apply(Builder<?> initialBuilder, TypeDescription typeDescription, ClassFileLocator classFileLocator) {
         Builder<?> builder = initialBuilder;
-        if (typeDescription.getActualName().equals(FakeMojo.class.getName())) {
+        if (typeDescription.getActualName().equals(FakeMojo.class.getName())
+                && typeDescription.getDeclaredFields().isEmpty()) {
             builder = transformFakeMojo(builder);
-        } else {
+        } else if (typeDescription.getActualName().equals(Property.class.getName())
+                && !typeDescription.getDeclaredAnnotations().isAnnotationPresent(Mojo.class)) {
             builder = transformPropertyEnum(builder);
         }
         return builder;


### PR DESCRIPTION
E.g. when building without clean.